### PR TITLE
Introduced Azure Table Storage post filtering (#537)

### DIFF
--- a/src/Core/SequenceExtensions.fs
+++ b/src/Core/SequenceExtensions.fs
@@ -41,6 +41,15 @@ let tryRandom = function
         |> random
         |> Some
 
+let tryRandomIf filters =
+    let combinedFilter x = 
+        filters 
+        |> Seq.map (fun f -> f x) 
+        |> Seq.fold (&&) true
+    
+    Seq.where combinedFilter 
+    >> tryRandom
+
 let tryExactlyOne = function
     | seq when not (seq |> Seq.length = 1) ->
         None

--- a/src/Core/Storage.fs
+++ b/src/Core/Storage.fs
@@ -71,13 +71,16 @@ let buildQuery<'T when 'T : (new : unit -> 'T) and 'T :> ITableEntity> filters =
         |> Seq.reduce combineFilters
         |> TableQuery<'T>().Where
 
-let tryGetRandom<'T when 'T : (new : unit -> 'T) and 'T :> ITableEntity> tableName azureFilters postFilters =
+let tryGetRandomWithFilters<'T when 'T : (new : unit -> 'T) and 'T :> ITableEntity> tableName azureFilters postFilters =
     let table = getTable tableName
-
+    
     azureFilters
     |> buildQuery<'T>
     |> table.ExecuteQuery
     |> Seq.tryRandomIf postFilters
+
+let tryGetRandom<'T when 'T : (new : unit -> 'T) and 'T :> ITableEntity> tableName azureFilters = 
+    tryGetRandomWithFilters<'T> tableName azureFilters []
 
 let getSingle<'T when 'T : (new : unit -> 'T) and 'T :> ITableEntity> tableName filters = 
     let table = getTable tableName

--- a/src/Core/Storage.fs
+++ b/src/Core/Storage.fs
@@ -43,7 +43,7 @@ let getAs<'T> = JsonConvert.DeserializeObject<'T>
 let getTable name =
     let connectionString = Environment.GetEnvironmentVariable "STORAGE_CONNECTIONSTRING"
     let account = CloudStorageAccount.Parse connectionString
-    let client = account.CreateCloudTableClient()
+    let client = account.CreateCloudTableClient() 
     let table = client.GetTableReference name
     table.CreateIfNotExists()
     table
@@ -71,13 +71,13 @@ let buildQuery<'T when 'T : (new : unit -> 'T) and 'T :> ITableEntity> filters =
         |> Seq.reduce combineFilters
         |> TableQuery<'T>().Where
 
-let tryGetRandom<'T when 'T : (new : unit -> 'T) and 'T :> ITableEntity> tableName filters =
+let tryGetRandom<'T when 'T : (new : unit -> 'T) and 'T :> ITableEntity> tableName azureFilters postFilters =
     let table = getTable tableName
 
-    filters
+    azureFilters
     |> buildQuery<'T>
     |> table.ExecuteQuery
-    |> Seq.tryRandom
+    |> Seq.tryRandomIf postFilters
 
 let getSingle<'T when 'T : (new : unit -> 'T) and 'T :> ITableEntity> tableName filters = 
     let table = getTable tableName

--- a/src/Server/WebServer.fs
+++ b/src/Server/WebServer.fs
@@ -27,7 +27,7 @@ let getNounPluralsTask next (ctx: HttpContext) =
             [ genderFilter; patternFilter ] 
             |> Seq.choose id
         
-        let noun = tryGetRandom<NounPlural.NounPlural> "nounplurals" filters
+        let noun = tryGetRandom<NounPlural.NounPlural> "nounplurals" filters []
         let getTask (noun: NounPlural.NounPlural) = 
             let singular = getAs<string> noun.Singular
             let plurals = getAs<string []> noun.Plurals
@@ -49,7 +49,7 @@ let getNounAccusativesTask next (ctx : HttpContext) =
             [ genderFilter; patternFilter ] 
             |> Seq.choose id
 
-        let noun = tryGetRandom<NounAccusative.NounAccusative> "nounaccusatives" filters
+        let noun = tryGetRandom<NounAccusative.NounAccusative> "nounaccusatives" filters []
         let getTask (noun: NounAccusative.NounAccusative) = 
             let singular = getAs<string> noun.Nominative 
             let accusatives = getAs<string []> noun.Accusatives
@@ -61,7 +61,7 @@ let getNounAccusativesTask next (ctx : HttpContext) =
 
 let getAdjectivePluralsTask next (ctx : HttpContext) =
     task { 
-        let adjective = tryGetRandom<AdjectivePlural.AdjectivePlural> "adjectiveplurals" []
+        let adjective = tryGetRandom<AdjectivePlural.AdjectivePlural> "adjectiveplurals" [] []
     
         let getTask (adjective: AdjectivePlural.AdjectivePlural) = 
             let singular = getAs<string> adjective.Singular
@@ -78,7 +78,7 @@ let getAdjectiveComparativesTask next (ctx : HttpContext) =
         let regularityFilter = getFilter "IsRegular" Bool regularityFromQuery
     
         let filters = [ regularityFilter ] |> Seq.choose id
-        let adjective = tryGetRandom<AdjectiveComparative.AdjectiveComparative> "adjectivecomparatives" filters
+        let adjective = tryGetRandom<AdjectiveComparative.AdjectiveComparative> "adjectivecomparatives" filters []
     
         let getTask (adjective: AdjectiveComparative.AdjectiveComparative) = 
             let positive = getAs<string> adjective.Positive
@@ -101,7 +101,7 @@ let getVerbImperativesTask next (ctx : HttpContext) =
             [ classFilter; patternFilter ]
             |> Seq.choose id
             
-        let verb = tryGetRandom<VerbImperative.VerbImperative> "verbimperatives" filters
+        let verb = tryGetRandom<VerbImperative.VerbImperative> "verbimperatives" filters []
 
         let getTask (verb: VerbImperative.VerbImperative) = 
             let indicative = getAs<string> verb.Indicative
@@ -124,7 +124,7 @@ let getVerbParticiplesTask next (ctx: HttpContext) =
             [ patternFilter; regularityFilter ] 
             |> Seq.choose id
         
-        let verb = tryGetRandom<VerbParticiple.VerbParticiple> "verbparticiples" filters
+        let verb = tryGetRandom<VerbParticiple.VerbParticiple> "verbparticiples" filters []
 
         let getTask (verb: VerbParticiple.VerbParticiple) = 
             let infinitive = getAs<string> verb.Infinitive

--- a/src/Server/WebServer.fs
+++ b/src/Server/WebServer.fs
@@ -27,7 +27,7 @@ let getNounPluralsTask next (ctx: HttpContext) =
             [ genderFilter; patternFilter ] 
             |> Seq.choose id
         
-        let noun = tryGetRandom<NounPlural.NounPlural> "nounplurals" filters []
+        let noun = tryGetRandom<NounPlural.NounPlural> "nounplurals" filters
         let getTask (noun: NounPlural.NounPlural) = 
             let singular = getAs<string> noun.Singular
             let plurals = getAs<string []> noun.Plurals
@@ -49,7 +49,7 @@ let getNounAccusativesTask next (ctx : HttpContext) =
             [ genderFilter; patternFilter ] 
             |> Seq.choose id
 
-        let noun = tryGetRandom<NounAccusative.NounAccusative> "nounaccusatives" filters []
+        let noun = tryGetRandom<NounAccusative.NounAccusative> "nounaccusatives" filters
         let getTask (noun: NounAccusative.NounAccusative) = 
             let singular = getAs<string> noun.Nominative 
             let accusatives = getAs<string []> noun.Accusatives
@@ -61,7 +61,7 @@ let getNounAccusativesTask next (ctx : HttpContext) =
 
 let getAdjectivePluralsTask next (ctx : HttpContext) =
     task { 
-        let adjective = tryGetRandom<AdjectivePlural.AdjectivePlural> "adjectiveplurals" [] []
+        let adjective = tryGetRandom<AdjectivePlural.AdjectivePlural> "adjectiveplurals" []
     
         let getTask (adjective: AdjectivePlural.AdjectivePlural) = 
             let singular = getAs<string> adjective.Singular
@@ -78,7 +78,7 @@ let getAdjectiveComparativesTask next (ctx : HttpContext) =
         let regularityFilter = getFilter "IsRegular" Bool regularityFromQuery
     
         let filters = [ regularityFilter ] |> Seq.choose id
-        let adjective = tryGetRandom<AdjectiveComparative.AdjectiveComparative> "adjectivecomparatives" filters []
+        let adjective = tryGetRandom<AdjectiveComparative.AdjectiveComparative> "adjectivecomparatives" filters
     
         let getTask (adjective: AdjectiveComparative.AdjectiveComparative) = 
             let positive = getAs<string> adjective.Positive
@@ -101,7 +101,7 @@ let getVerbImperativesTask next (ctx : HttpContext) =
             [ classFilter; patternFilter ]
             |> Seq.choose id
             
-        let verb = tryGetRandom<VerbImperative.VerbImperative> "verbimperatives" filters []
+        let verb = tryGetRandom<VerbImperative.VerbImperative> "verbimperatives" filters
 
         let getTask (verb: VerbImperative.VerbImperative) = 
             let indicative = getAs<string> verb.Indicative
@@ -124,7 +124,7 @@ let getVerbParticiplesTask next (ctx: HttpContext) =
             [ patternFilter; regularityFilter ] 
             |> Seq.choose id
         
-        let verb = tryGetRandom<VerbParticiple.VerbParticiple> "verbparticiples" filters []
+        let verb = tryGetRandom<VerbParticiple.VerbParticiple> "verbparticiples" filters
 
         let getTask (verb: VerbParticiple.VerbParticiple) = 
             let infinitive = getAs<string> verb.Infinitive


### PR DESCRIPTION
Details and reasons are in the task. Basically, this will allow to do us client filtering after Azure filtering, e.g.
```fsharp
// gender = 'hrad'
// patterns = '["růže","píseň"]'
let patternFilter (noun: NounPlural.NounPlural) = noun.Pattern.Contains patternFromQuery
let noun = tryGetRandom<NounPlural.NounPlural> "nounplurals" [genderFilter] [patternFilter]
```