### PR TITLE
Implemented cache busting (#553)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,10 @@ bin/
 packages/
 paket-files/
 node_modules/
-src/Client/public/app.js
-src/Client/public/vendors.js
-src/Client/public/style.js
-src/Client/public/style.css
+src/Client/public/app.*.js
+src/Client/public/vendors.*.js
+src/Client/public/style.*.js
+src/Client/public/style.*.css
 src/Client/public/index.html
 src/Server/Properties/launchSettings.json
 release.cmd

--- a/src/Client/webpack.common.js
+++ b/src/Client/webpack.common.js
@@ -11,10 +11,6 @@ module.exports = {
         ],
         "style": [ path.join(__dirname, './scss/main.scss') ]
     },
-    output: {
-        path: path.join(__dirname, "public"),
-        filename: "[name].js"
-    },
     resolve: {
         symlinks: false
     },

--- a/src/Client/webpack.development.js
+++ b/src/Client/webpack.development.js
@@ -6,6 +6,10 @@ const commonConfiguration = require("./webpack.common");
 
 module.exports = merge(commonConfiguration, {
     mode: "development",
+    output: {
+        path: path.join(__dirname, "public"),
+        filename: "[name].js"
+    },
     devtool: "source-map",
     plugins:     [
         new webpack.HotModuleReplacementPlugin(),

--- a/src/Client/webpack.production.js
+++ b/src/Client/webpack.production.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const MinifyPlugin = require("terser-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
@@ -9,8 +10,12 @@ module.exports = merge(commonConfiguration, {
     optimization: {
         minimizer: [ new MinifyPlugin() ]
     },
+    output: {
+        path: path.join(__dirname, "public"),
+        filename: "[name].[contenthash].js"
+    },
     plugins: [
-        new MiniCssExtractPlugin({ filename: 'style.css' })
+        new MiniCssExtractPlugin({ filename: 'style.[contenthash].css' })
     ],
     module: {
         rules: [


### PR DESCRIPTION
This basically leverages webpack's cache busting [capabilities](https://webpack.js.org/guides/caching/). Now we include the file content hash in the name of static resources. If any change is made, the hash will be completely different and it will force browsers to request the new version of the resource from the server. 

If we don't do it, browsers can take file content from the cache and prevent users from seeing real changes made. 