### PR TITLE
Minor improvements for webpack dev server

### DIFF
--- a/src/Client/webpack.development.js
+++ b/src/Client/webpack.development.js
@@ -18,15 +18,10 @@ module.exports = merge(commonConfiguration, {
     devServer: {
         proxy: {
             '/api/*': {
-                target: 'http://localhost:8085',
-                changeOrigin: true
+                target: 'http://localhost:8085'
             }
         },
         hot: true,
-        inline: true,
-        historyApiFallback: {
-            index: path.join(__dirname, "./public/index.html")
-        },
         contentBase: path.join(__dirname, "public")
     },
     module: {


### PR DESCRIPTION
This includes easier and faster way to open browser (via webpack options instead of separate process), removing some default values (e.g. [inline](https://webpack.js.org/configuration/dev-server/#devserverinline)) and unneeded values (e.g. [historyApiFallback](https://webpack.js.org/configuration/dev-server/#devserverhistoryapifallback)).