### PR TITLE
Fixed bug with the město pattern

### DIFF
--- a/src/Core/NeuterNounPatternDetector.fs
+++ b/src/Core/NeuterNounPatternDetector.fs
@@ -36,7 +36,7 @@ let getPattern = function
     | _ -> None
 
 let patternDetectors = [
-    (isPatternMěsto, "okno")
+    (isPatternMěsto, "město")
     (isPatternMoře, "moře")
     (isPatternStavení, "stavení")
     (isPatternKuře, "kuře")


### PR DESCRIPTION
I guess I accidentally changed the pattern detector while some experiments there. Therefore words relevant words were assigned "okno" pattern whereas the API still asked for "město" pattern.