### PR TITLE
Fixed generation of redundant style.js (#564)

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -55,6 +55,7 @@
     <!-- Paket command -->
     <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
     <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</PaketCommand>
+    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(_PaketExeExtension)' == '' ">dotnet "$(PaketExePath)"</PaketCommand>
     <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
     <PaketCommand Condition=" '$(PaketCommand)' == '' ">"$(PaketExePath)"</PaketCommand>
 

--- a/src/Client/resources.js
+++ b/src/Client/resources.js
@@ -3,5 +3,7 @@ import './images/incorrect.png';
 import './images/question_mark.png';
 import './images/loading.gif';
 
+import './scss/main.scss';
+
 import './favicon.ico';
 import './robots.txt';

--- a/src/Client/webpack.common.js
+++ b/src/Client/webpack.common.js
@@ -9,8 +9,7 @@ module.exports = {
             "@babel/polyfill",
             path.join(__dirname, "./Client.fsproj")
         ],
-        "recources": path.join(__dirname, './recources.js'),
-        "style": [ path.join(__dirname, './scss/main.scss') ]
+        "resources": path.join(__dirname, './resources.js')
     },
     resolve: {
         symlinks: false


### PR DESCRIPTION
It looks like a [more canonical way](https://stackoverflow.com/questions/35322958/can-i-use-webpack-to-generate-css-and-js-separately) for webpack is to load styles as resources. It also helps to avoid generating and referencing unneeded js files with styles.