### PR TITLE
Added the Drama pattern to neuters (#530)

### DIFF
--- a/src/Client/pages/NounAccusatives.fs
+++ b/src/Client/pages/NounAccusatives.fs
@@ -22,7 +22,7 @@ let patterns =
     dict [ (MasculineAnimate, ["pan"; "muž"; "předseda"; "soudce"])
            (MasculineInanimate, ["hrad"; "stroj"])
            (Feminine, ["žena"; "růže"; "píseň"; "kost"])
-           (Neuter, ["město"; "kuře"; "moře"; "stavení"]) ]
+           (Neuter, ["město"; "kuře"; "moře"; "stavení"; "drama"]) ]
 
 let getPatterns gender = patterns.[gender]
 

--- a/src/Client/pages/NounPlurals.fs
+++ b/src/Client/pages/NounPlurals.fs
@@ -22,7 +22,7 @@ let patterns =
     dict [ (MasculineAnimate, ["pan"; "muž"; "předseda"; "soudce"])
            (MasculineInanimate, ["hrad"; "stroj"])
            (Feminine, ["žena"; "růže"; "píseň"; "kost"])
-           (Neuter, ["město"; "kuře"; "moře"; "stavení"]) ]
+           (Neuter, ["město"; "kuře"; "moře"; "stavení"; "drama"]) ]
 
 let getPatterns gender = patterns.[gender]
 

--- a/src/Core/NeuterNounPatternDetector.fs
+++ b/src/Core/NeuterNounPatternDetector.fs
@@ -28,18 +28,19 @@ let isPatternKuře word =
     singulars |> Seq.exists (endsOneOf ["e"; "ě"]) &&
     plurals |> Seq.exists (ends "ata")
 
-let getPattern = function
-    | word when word |> isPatternMěsto -> Some "pan"
-    | word when word |> isPatternMoře -> Some "muž"
-    | word when word |> isPatternStavení -> Some "předseda"
-    | word when word |> isPatternKuře -> Some "soudce"
-    | _ -> None
+let isPatternDrama word =
+    let nominatives = word |> getDeclension Case.Nominative Number.Singular
+    let accusatives = word |> getDeclension Case.Accusative Number.Singular
+
+    nominatives |> Seq.exists (ends "ma") &&
+    accusatives |> Seq.exists (ends "ma")
 
 let patternDetectors = [
     (isPatternMěsto, "město")
     (isPatternMoře, "moře")
     (isPatternStavení, "stavení")
     (isPatternKuře, "kuře")
+    (isPatternDrama, "drama")
 ]
 
 let isPattern word patternDetector = fst patternDetector word

--- a/tests/Core.IntegrationTests/NeuterNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/NeuterNounPatternDetectorTests.fs
@@ -85,8 +85,25 @@ let ``Detects not pattern kuře`` word =
     |> Assert.False
 
 [<Theory>]
-[<InlineData "faktum">]
 [<InlineData "téma">]
+[<InlineData "dilema">]
+let ``Detects pattern drama`` word =
+    word
+    |> isPatternDrama
+    |> Assert.True
+
+[<Theory>]
+[<InlineData "pole">]
+[<InlineData "stavení">]
+[<InlineData "okno">]
+[<InlineData "kuře">]
+let ``Detects not pattern drama`` word =
+    word
+    |> isPatternDrama
+    |> Assert.False
+
+[<Theory>]
+[<InlineData "faktum">]
 [<InlineData "buly">]
 [<InlineData "břímě">]
 let ``Detects no patterns`` word =


### PR DESCRIPTION
This is a relatively easy pattern to add, its detection is quite easy. Detection code is based on what is written [in official grammar](http://prirucka.ujc.cas.cz/?slovo=drama#nadpis2_8).

Tests are added. Also, there was some obsolete, unused and wrong function `getPattern`, I removed it.