### PR TITLE
Improved Drama pattern detection (#530)

### DIFF
--- a/src/Core/NeuterNounPatternDetector.fs
+++ b/src/Core/NeuterNounPatternDetector.fs
@@ -29,11 +29,11 @@ let isPatternKuře word =
     plurals |> Seq.exists (ends "ata")
 
 let isPatternDrama word =
-    let nominatives = word |> getDeclension Case.Nominative Number.Singular
-    let accusatives = word |> getDeclension Case.Accusative Number.Singular
+    let singulars = word |> getDeclension Case.Nominative Number.Singular
+    let plurals = word |> getDeclension Case.Nominative Number.Plural
 
-    nominatives |> Seq.exists (ends "ma") &&
-    accusatives |> Seq.exists (ends "ma")
+    singulars |> Seq.exists (ends "ma") &&
+    plurals |> Seq.exists (ends "mata")
 
 let patternDetectors = [
     (isPatternMěsto, "město")

--- a/tests/Core.IntegrationTests/NeuterNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/NeuterNounPatternDetectorTests.fs
@@ -97,6 +97,7 @@ let ``Detects pattern drama`` word =
 [<InlineData "stavení">]
 [<InlineData "okno">]
 [<InlineData "kuře">]
+[<InlineData "pyžama">]
 let ``Detects not pattern drama`` word =
     word
     |> isPatternDrama


### PR DESCRIPTION
Okay, so looks like checking nominatives and accusatives was not enough because there are words like [pyžama](http://prirucka.ujc.cas.cz/?slovo=py%C5%BEama), which are neuter and have "ma" in both those cases but don't belong do the Drama pattern. 

Here is an improved pattern detection algorithm.