### PR TITLE
Handling nouns with multiple declensions (#573)

### DIFF
--- a/src/Core/Article.fs
+++ b/src/Core/Article.fs
@@ -109,6 +109,11 @@ let getChildrenParts elements =
     | None -> 
         Seq.empty
 
+let getChildrenPartsWhen filter =
+    getChildrenParts
+    >> Seq.where (fun (header, _) -> filter header)
+    >> Seq.map snd
+
 let getParts name =
     getAllParts
     >> Seq.where (fun (header, _) -> header = name)
@@ -133,4 +138,5 @@ let tryFunc2 func x y = try func x y |> Some with | :? KeyNotFoundException | :?
 let tryGetTableOfContents word = tryFunc1 getTableOfContents word
 let tryGetContent word = tryFunc1 getContent word
 let tryGetChildPart name elements = tryFunc2 getChildPart name elements
+let tryGetChildrenPartsWhen filter = tryFunc2 getChildrenPartsWhen filter
 let tryGetInfo name elements = tryFunc2 getInfo name elements

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -29,6 +29,8 @@
     <Compile Include="ComparativeBuilder.fs" />
     <Compile Include="ParticipleBuilder.fs" />
     <Compile Include="ParticiplePatternDetector.fs" />
+    <Compile Include="NounCategories.fs" />
+    <Compile Include="WikiDeclensions.fs" />
     <Compile Include="Declensions.fs" />
     <Compile Include="FeminineNounPatternDetector.fs.fs" />
     <Compile Include="NeuterNounPatternDetector.fs" />

--- a/src/Core/Core.fsproj
+++ b/src/Core/Core.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="WikiString.fs" />
     <Compile Include="Html.fs" />
     <Compile Include="Stem.fs" />
+    <Compile Include="GrammarCategories.fs" />
     <Compile Include="Storage.fs" />
     <Compile Include="Genders.fs" />
     <Compile Include="Article.fs" />
@@ -29,7 +30,6 @@
     <Compile Include="ComparativeBuilder.fs" />
     <Compile Include="ParticipleBuilder.fs" />
     <Compile Include="ParticiplePatternDetector.fs" />
-    <Compile Include="NounCategories.fs" />
     <Compile Include="WikiDeclensions.fs" />
     <Compile Include="Declensions.fs" />
     <Compile Include="FeminineNounPatternDetector.fs.fs" />

--- a/src/Core/Declensions.fs
+++ b/src/Core/Declensions.fs
@@ -2,7 +2,7 @@
 
 open Article
 open WikiString
-open NounCategories
+open GrammarCategories
 open StringHelper
 
 let isIndeclinable = 

--- a/src/Core/Declensions.fs
+++ b/src/Core/Declensions.fs
@@ -1,38 +1,17 @@
 ﻿module Declensions
 
-open FSharp.Data
 open Article
 open WikiString
-open ArticleParser
-
-type EditableArticle = HtmlProvider<"https://cs.wiktionary.org/wiki/panda">
-type LockedArticle = HtmlProvider<"https://cs.wiktionary.org/wiki/debil">
-
-type Case = 
-    | Nominative = 0
-    | Genitive = 1
-    | Dative = 2
-    | Accusative = 3
-    | Vocative = 4
-    | Locative = 5
-    | Instrumental = 6
-
-type Number =
-    | Singular
-    | Plural
-
-let hasDeclension = 
-    tryGetNoun
-    >> Option.bind (tryGetChildPart "skloňování")
-    >> Option.isSome
+open NounCategories
+open StringHelper
 
 let isIndeclinable = 
     getContent
     >> getChildPart "čeština"
     >> getChildPart "podstatné jméno"
-    >> getChildPart "skloňování"
-    >> tryGetInfo "nesklonné"
-    >> Option.isSome
+    >> getChildrenPartsWhen (starts "skloňování")
+    >> Seq.map (tryGetInfo "nesklonné")
+    >> Seq.forall Option.isSome
 
 let isNominalization (noun: string) =
     let adjectiveEndings = ['ý'; 'á'; 'é'; 'í']
@@ -41,36 +20,21 @@ let isNominalization (noun: string) =
 
 let isNotNominalization = not << isNominalization
 
-let getUrl = (+) "https://cs.wiktionary.org/wiki/"
-
-let getDeclensionWikiEditable case number word =
-    let data = word |> getUrl |> EditableArticle.Load
-    match number with
-    | Singular ->
-        data.Tables.``Skloňování[editovat]``.Rows.[case].singulár
-    | Plural -> 
-        data.Tables.``Skloňování[editovat]``.Rows.[case].plurál
-
-let getDeclensionWikiLocked case number word =
-    let data = word |> getUrl |> LockedArticle.Load
-    match number with
-    | Singular ->
-        data.Tables.Skloňování.Rows.[case].singulár
-    | Plural -> 
-        data.Tables.Skloňování.Rows.[case].plurál
-
 let getDeclensionWiki (case: Case) number word = 
     match word with
     | _ when word |> isIndeclinable ->
-        word
+        [ word ]
     | _ when word |> isEditable ->
-        getDeclensionWikiEditable (int case) number word
+        WikiDeclensions.getEditable (int case) number word
     | _ when word |> isLocked ->
-        getDeclensionWikiLocked (int case) number word
+        WikiDeclensions.getLocked (int case) number word
     | word -> 
         invalidOp ("Odd word: " + word)
 
-let getDeclension case number = getDeclensionWiki case number >> getForms
+let getDeclension case number = 
+    getDeclensionWiki case number 
+    >> Seq.collect getForms
+    >> Seq.distinct
 
 let hasSingleDeclensionForCase case number = 
     getDeclension case number

--- a/src/Core/FeminineNounPatternDetector.fs.fs
+++ b/src/Core/FeminineNounPatternDetector.fs.fs
@@ -2,6 +2,7 @@
 
 open Declensions
 open StringHelper
+open NounCategories
 
 let isPatternŽena word = 
     let nominatives = word |> getDeclension Case.Nominative Number.Singular

--- a/src/Core/FeminineNounPatternDetector.fs.fs
+++ b/src/Core/FeminineNounPatternDetector.fs.fs
@@ -2,7 +2,7 @@
 
 open Declensions
 open StringHelper
-open NounCategories
+open GrammarCategories
 
 let isPatternŽena word = 
     let nominatives = word |> getDeclension Case.Nominative Number.Singular

--- a/src/Core/GrammarCategories.fs
+++ b/src/Core/GrammarCategories.fs
@@ -1,4 +1,4 @@
-﻿module NounCategories
+﻿module GrammarCategories
 
 type Case = 
     | Nominative = 0

--- a/src/Core/MasculineAnimateNounPatternDetector.fs
+++ b/src/Core/MasculineAnimateNounPatternDetector.fs
@@ -2,7 +2,7 @@
 
 open Declensions
 open StringHelper
-open NounCategories
+open GrammarCategories
 
 let isPatternPan = 
     getDeclension Case.Genitive Number.Singular

--- a/src/Core/MasculineAnimateNounPatternDetector.fs
+++ b/src/Core/MasculineAnimateNounPatternDetector.fs
@@ -2,6 +2,7 @@
 
 open Declensions
 open StringHelper
+open NounCategories
 
 let isPatternPan = 
     getDeclension Case.Genitive Number.Singular

--- a/src/Core/MasculineInanimateNounPatternDetector.fs
+++ b/src/Core/MasculineInanimateNounPatternDetector.fs
@@ -2,7 +2,7 @@
 
 open Declensions
 open StringHelper
-open NounCategories
+open GrammarCategories
 
 let isPatternHrad = 
     getDeclension Case.Genitive Number.Singular

--- a/src/Core/MasculineInanimateNounPatternDetector.fs
+++ b/src/Core/MasculineInanimateNounPatternDetector.fs
@@ -2,6 +2,7 @@
 
 open Declensions
 open StringHelper
+open NounCategories
 
 let isPatternHrad = 
     getDeclension Case.Genitive Number.Singular

--- a/src/Core/NeuterNounPatternDetector.fs
+++ b/src/Core/NeuterNounPatternDetector.fs
@@ -2,6 +2,7 @@
 
 open Declensions
 open StringHelper
+open NounCategories
 
 let isPatternMěsto word = 
     let nominatives = word |> getDeclension Case.Nominative Number.Singular

--- a/src/Core/NeuterNounPatternDetector.fs
+++ b/src/Core/NeuterNounPatternDetector.fs
@@ -2,7 +2,7 @@
 
 open Declensions
 open StringHelper
-open NounCategories
+open GrammarCategories
 
 let isPatternMěsto word = 
     let nominatives = word |> getDeclension Case.Nominative Number.Singular

--- a/src/Core/Noun.fs
+++ b/src/Core/Noun.fs
@@ -4,13 +4,12 @@ open FSharp.Data
 open Article
 open Genders
 open ArticleParser
-
-type EditableArticle = HtmlProvider<"https://cs.wiktionary.org/wiki/panda">
-type LockedArticle = HtmlProvider<"https://cs.wiktionary.org/wiki/debil">
+open StringHelper
 
 let hasDeclension = 
     tryGetNoun
-    >> Option.bind (tryGetChildPart "skloňování")
+    >> Option.bind (tryGetChildrenPartsWhen (starts "skloňování"))
+    >> Option.filter (not << Seq.isEmpty)
     >> Option.isSome
 
 let hasGender =

--- a/src/Core/NounAccusative.fs
+++ b/src/Core/NounAccusative.fs
@@ -7,10 +7,10 @@ let isValid word =
     word |> Noun.isNotNominalization &&
     word |> Noun.hasDeclension &&
     word |> Noun.hasGender &&
-    word |> Declensions.hasSingleDeclensionForCase NounCategories.Case.Nominative NounCategories.Number.Singular
+    word |> Declensions.hasSingleDeclensionForCase GrammarCategories.Case.Nominative GrammarCategories.Number.Singular
 
 let getNominative = Storage.mapSafeString id
-let getAccusatives = Storage.mapSafeString (Declensions.getDeclension NounCategories.Case.Accusative NounCategories.Number.Singular)
+let getAccusatives = Storage.mapSafeString (Declensions.getDeclension GrammarCategories.Case.Accusative GrammarCategories.Number.Singular)
 let getGender = Storage.mapSafeObject (Noun.getGender >> box)
 let getPatterns = Storage.mapSafeString Noun.getPatterns
 

--- a/src/Core/NounAccusative.fs
+++ b/src/Core/NounAccusative.fs
@@ -7,10 +7,10 @@ let isValid word =
     word |> Noun.isNotNominalization &&
     word |> Noun.hasDeclension &&
     word |> Noun.hasGender &&
-    word |> Declensions.hasSingleDeclensionForCase Declensions.Case.Nominative Declensions.Number.Singular
+    word |> Declensions.hasSingleDeclensionForCase NounCategories.Case.Nominative NounCategories.Number.Singular
 
 let getNominative = Storage.mapSafeString id
-let getAccusatives = Storage.mapSafeString (Declensions.getDeclension Declensions.Case.Accusative Declensions.Number.Singular)
+let getAccusatives = Storage.mapSafeString (Declensions.getDeclension NounCategories.Case.Accusative NounCategories.Number.Singular)
 let getGender = Storage.mapSafeObject (Noun.getGender >> box)
 let getPatterns = Storage.mapSafeString Noun.getPatterns
 

--- a/src/Core/NounCategories.fs
+++ b/src/Core/NounCategories.fs
@@ -1,0 +1,14 @@
+﻿module NounCategories
+
+type Case = 
+    | Nominative = 0
+    | Genitive = 1
+    | Dative = 2
+    | Accusative = 3
+    | Vocative = 4
+    | Locative = 5
+    | Instrumental = 6
+
+type Number =
+    | Singular
+    | Plural

--- a/src/Core/NounPlural.fs
+++ b/src/Core/NounPlural.fs
@@ -7,11 +7,11 @@ let isValid word =
     word |> Noun.isNotNominalization &&
     word |> Noun.hasDeclension &&
     word |> Noun.hasGender &&
-    word |> Declensions.hasSingleDeclensionForCase Declensions.Case.Nominative Declensions.Number.Singular &&
-    word |> Declensions.hasDeclensionForCase Declensions.Case.Nominative Declensions.Number.Plural
+    word |> Declensions.hasSingleDeclensionForCase NounCategories.Case.Nominative NounCategories.Number.Singular &&
+    word |> Declensions.hasDeclensionForCase NounCategories.Case.Nominative NounCategories.Number.Plural
 
 let getSingular = Storage.mapSafeString id
-let getPlurals = Storage.mapSafeString (Declensions.getDeclension Declensions.Case.Nominative Declensions.Number.Plural)
+let getPlurals = Storage.mapSafeString (Declensions.getDeclension NounCategories.Case.Nominative NounCategories.Number.Plural)
 let getGender = Storage.mapSafeObject (Noun.getGender >> box)
 let getPatterns = Storage.mapSafeString Noun.getPatterns
 

--- a/src/Core/NounPlural.fs
+++ b/src/Core/NounPlural.fs
@@ -7,11 +7,11 @@ let isValid word =
     word |> Noun.isNotNominalization &&
     word |> Noun.hasDeclension &&
     word |> Noun.hasGender &&
-    word |> Declensions.hasSingleDeclensionForCase NounCategories.Case.Nominative NounCategories.Number.Singular &&
-    word |> Declensions.hasDeclensionForCase NounCategories.Case.Nominative NounCategories.Number.Plural
+    word |> Declensions.hasSingleDeclensionForCase GrammarCategories.Case.Nominative GrammarCategories.Number.Singular &&
+    word |> Declensions.hasDeclensionForCase GrammarCategories.Case.Nominative GrammarCategories.Number.Plural
 
 let getSingular = Storage.mapSafeString id
-let getPlurals = Storage.mapSafeString (Declensions.getDeclension NounCategories.Case.Nominative NounCategories.Number.Plural)
+let getPlurals = Storage.mapSafeString (Declensions.getDeclension GrammarCategories.Case.Nominative GrammarCategories.Number.Plural)
 let getGender = Storage.mapSafeObject (Noun.getGender >> box)
 let getPatterns = Storage.mapSafeString Noun.getPatterns
 

--- a/src/Core/WikiDeclensions.fs
+++ b/src/Core/WikiDeclensions.fs
@@ -1,0 +1,50 @@
+﻿module WikiDeclensions
+
+open FSharp.Data
+open NounCategories
+open Article
+open StringHelper
+
+type EditableArticleOneDeclension = HtmlProvider<"https://cs.wiktionary.org/wiki/panda">
+type EditableArticleTwoDeclensions = HtmlProvider<"https://cs.wiktionary.org/wiki/čtvrt">
+type LockedArticle = HtmlProvider<"https://cs.wiktionary.org/wiki/debil">
+
+let getUrl = (+) "https://cs.wiktionary.org/wiki/"
+
+let getNumberOfDeclensions =
+    getContent
+    >> getChildPart "čeština"
+    >> getChildPart "podstatné jméno"
+    >> getChildrenPartsWhen (starts "skloňování")
+    >> Seq.length
+
+let getEditable case number word =
+    let numberOfDeclensions = getNumberOfDeclensions word
+    let url = getUrl word
+    match numberOfDeclensions with
+    | 1 ->
+        let data = EditableArticleOneDeclension.Load url
+        match number with
+        | Singular ->
+            [ data.Tables.``Skloňování[editovat]``.Rows.[case].singulár ]
+        | Plural -> 
+            [ data.Tables.``Skloňování[editovat]``.Rows.[case].plurál ]
+    | 2 ->
+        let data = EditableArticleTwoDeclensions.Load url
+        match number with
+        | Singular ->
+            [ data.Tables.``Skloňování (1)[editovat]``.Rows.[case].singulár 
+              data.Tables.``Skloňování (2)[editovat]``.Rows.[case].singulár ]
+        | Plural -> 
+            [ data.Tables.``Skloňování (1)[editovat]``.Rows.[case].plurál 
+              data.Tables.``Skloňování (2)[editovat]``.Rows.[case].plurál ]
+    | _ ->
+        invalidOp ("Odd word: " + word)
+
+let getLocked case number word =
+    let data = word |> getUrl |> LockedArticle.Load
+    match number with
+    | Singular ->
+        [ data.Tables.Skloňování.Rows.[case].singulár ]
+    | Plural -> 
+        [ data.Tables.Skloňování.Rows.[case].plurál ]

--- a/src/Core/WikiDeclensions.fs
+++ b/src/Core/WikiDeclensions.fs
@@ -1,7 +1,7 @@
 ﻿module WikiDeclensions
 
 open FSharp.Data
-open NounCategories
+open GrammarCategories
 open Article
 open StringHelper
 

--- a/tests/Core.IntegrationTests/DeclensionsTests.fs
+++ b/tests/Core.IntegrationTests/DeclensionsTests.fs
@@ -2,50 +2,59 @@
 
 open Xunit
 open Declensions
+open Noun
+open NounCategories
 
 let equals (expected: 'T) (actual: 'T) = Assert.Equal<'T>(expected, actual)
+let seqEquals (expected: 'T list) (actual: seq<'T>) = Assert.Equal<'T>(expected, Seq.toList actual)
 
 [<Fact>]
 let ``Gets declension wiki - indeclinable``() = 
     "dada"
     |> getDeclensionWiki Case.Nominative Number.Plural
-    |> equals "dada"
+    |> equals ["dada"]
 
 [<Fact>]
 let ``Gets declension wiki - editable article``() = 
     "panda"
     |> getDeclensionWiki Case.Nominative Number.Plural
-    |> equals "pandy"
+    |> equals ["pandy"]
 
 [<Fact>]
 let ``Gets wiki plural wiki - locked article``() = 
     "debil"
     |> getDeclensionWiki Case.Nominative Number.Plural
-    |> equals "debilové"
+    |> equals ["debilové"]
 
 [<Fact>]
 let ``Gets declension for case - indeclinable``() =
     "dada"
     |> getDeclension Case.Nominative Number.Singular
-    |> equals [|"dada"|]
+    |> seqEquals ["dada"]
 
 [<Fact>]
 let ``Gets declension for case - single option``() =
     "hrad"
     |> getDeclension Case.Nominative Number.Singular
-    |> equals [|"hrad"|]
+    |> seqEquals ["hrad"]
 
 [<Fact>]
 let ``Gets declension for case - no options``() =
     "záda"
     |> getDeclension Case.Nominative Number.Singular
-    |> equals [||]
+    |> seqEquals []
+
+[<Fact>]
+let ``Gets declension - multiple declensions``() =
+    "čtvrt"
+    |> getDeclension Case.Nominative Number.Plural
+    |> seqEquals ["čtvrtě"; "čtvrti"]
 
 [<Fact>]
 let ``Gets singulars - multiple options``() =
     "temeno"
     |> getDeclension Case.Nominative Number.Singular
-    |> equals [|"temeno"; "témě"|]
+    |> seqEquals ["temeno"; "témě"]
     
 [<Fact>]
 let ``Detects indeclinable``() =
@@ -90,7 +99,14 @@ let ``Detects declension``() =
     |> Assert.True
 
 [<Fact>]
+let ``Detects multiple declensions``() =
+    "čtvrť"
+    |> hasDeclension
+    |> Assert.True
+
+[<Fact>]
 let ``Detects no declension``() =
     "antilopu"
     |> hasDeclension
     |> Assert.False
+

--- a/tests/Core.IntegrationTests/DeclensionsTests.fs
+++ b/tests/Core.IntegrationTests/DeclensionsTests.fs
@@ -3,7 +3,7 @@
 open Xunit
 open Declensions
 open Noun
-open NounCategories
+open GrammarCategories
 
 let equals (expected: 'T) (actual: 'T) = Assert.Equal<'T>(expected, actual)
 let seqEquals (expected: 'T list) (actual: seq<'T>) = Assert.Equal<'T>(expected, Seq.toList actual)


### PR DESCRIPTION
Examples and details are given in the related task.

This is what's happening in the PR:
1) Two modules are extracted from the `Declensions` module: `NounCategories` (just noun properties) and `WikiDeclensions` (logic of extracting declensions from wiki for all currently known possible structure of the page)
2) `IsIndeclinable` and `hasDeclension` functions now utilize the new `getChildrenPartsWhen` function which returns true both for single and multiple _skloňování_ sections
3) `getDeclension` function in the `Declensions` module now collects the results from all the declensions section
4) Two tests for that are added, I also ran Scraper locally to verify that now it does record such words to the database