### PR TITLE
Forcing HTTPS for the service (#578)

### DIFF
--- a/src/Client/webpack.development.js
+++ b/src/Client/webpack.development.js
@@ -19,7 +19,7 @@ module.exports = merge(commonConfiguration, {
         proxy: {
             '/api/*': {
                 target: 'https://localhost:8085',
-				secure: false
+                secure: false
             }
         },
         hot: true,

--- a/src/Client/webpack.development.js
+++ b/src/Client/webpack.development.js
@@ -18,7 +18,8 @@ module.exports = merge(commonConfiguration, {
     devServer: {
         proxy: {
             '/api/*': {
-                target: 'http://localhost:8085'
+                target: 'https://localhost:8085',
+				secure: false
             }
         },
         hot: true,

--- a/src/Server/Program.fs
+++ b/src/Server/Program.fs
@@ -25,6 +25,7 @@ let configureAzure (services:IServiceCollection) =
 
 let app = application {
     url ("http://0.0.0.0:" + port.ToString() + "/")
+    force_ssl
     use_router WebServer.webApp
     memory_cache
     use_static publicPath

--- a/src/Server/Program.fs
+++ b/src/Server/Program.fs
@@ -24,7 +24,7 @@ let configureAzure (services:IServiceCollection) =
     |> Option.defaultValue services
 
 let app = application {
-    url ("http://0.0.0.0:" + port.ToString() + "/")
+    url ("https://0.0.0.0:" + port.ToString() + "/")
     force_ssl
     use_router WebServer.webApp
     memory_cache


### PR DESCRIPTION
Server is changed according to [Saturn](https://saturnframework.org/docs/api/application/#force_ssl) docs, dev server side is changed according to the [webpack](https://webpack.js.org/configuration/dev-server/#devserverproxy) docs.

This way HTTPS is indeed forced (I deployed the app to the test slot) whereas locally things still work.