### PR TITLE
Simplified article scanning (#266)

### DIFF
--- a/src/Common/Conjugation.fs
+++ b/src/Common/Conjugation.fs
@@ -1,10 +1,5 @@
 module Conjugation
 
-open System
-open System.Collections.Generic
-
-open GrammarCategories
-
 type Pronoun =
     | FirstSingular 
     | SecondSingular 
@@ -13,8 +8,7 @@ type Pronoun =
     | SecondPlural 
     | ThirdPlural
 
-let pronounToString pronoun =
-    match pronoun with
+let pronounToString = function
     | FirstSingular   -> "já"
     | SecondSingular  -> "ty"
     | ThirdSingular   -> "ono"

--- a/src/Core/Validation/AdjectiveValidation.fs
+++ b/src/Core/Validation/AdjectiveValidation.fs
@@ -12,14 +12,12 @@ let hasMorphologicalComparatives =
 
 let hasRequiredInfoComparative =
     isMatch [
-        Is "čeština"
         Is "přídavné jméno"
         Is "stupňování"
     ]
 
 let hasRequiredInfoPlural = 
     isMatch [
-        Is "čeština"
         Is "přídavné jméno"
         Is "skloňování"
     ]

--- a/src/Core/Validation/AdjectiveValidation.fs
+++ b/src/Core/Validation/AdjectiveValidation.fs
@@ -10,20 +10,19 @@ let hasMorphologicalComparatives =
     >> Array.filter isMorphologicalComparison
     >> (not << Seq.isEmpty)
 
-let tryGetAdjective =
-    tryGetContent
-    >> Option.filter (hasChildPart "čeština")
-    >> Option.map (getChildPart "čeština")
-    >> Option.filter (hasChildPart "přídavné jméno")
-    >> Option.map (getChildPart "přídavné jméno")
-
 let hasRequiredInfoComparative =
-    tryGetAdjective
-    >> Option.exists (hasChildPart "stupňování")
+    isMatch [
+        Is "čeština"
+        Is "přídavné jméno"
+        Is "stupňování"
+    ]
 
 let hasRequiredInfoPlural = 
-    tryGetAdjective 
-    >> Option.exists (hasChildPart "skloňování")
+    isMatch [
+        Is "čeština"
+        Is "přídavné jméno"
+        Is "skloňování"
+    ]
 
 let isValidAdjective = isPositive
 

--- a/src/Core/Validation/NounValidation.fs
+++ b/src/Core/Validation/NounValidation.fs
@@ -23,7 +23,6 @@ let hasDeclension case number =
 let hasRequiredInfo word =
     word
     |> isMatch [
-        Is "čeština"
         Is "podstatné jméno"
         Starts "skloňování"
     ]
@@ -32,7 +31,6 @@ let hasRequiredInfo word =
 
     word
     |> ``match`` [
-        Is "čeština"
         Is "podstatné jméno"
     ] 
     |> Option.exists (hasInfo (Starts "rod"))

--- a/src/Core/Validation/NounValidation.fs
+++ b/src/Core/Validation/NounValidation.fs
@@ -5,7 +5,6 @@ open GrammarCategories
 open Article
 open NounArticle
 open Genders
-open StringHelper
 open Nominalization
 
 let isGenderValid = 
@@ -21,18 +20,22 @@ let hasDeclension case number =
     getDeclension case number
     >> Seq.any
 
-let hasRequiredInfo =
-    let hasDeclension = hasChildrenPartsWhen (starts "skloňování")
-    let hasGender = hasInfo "rod"
+let hasRequiredInfo word =
+    word
+    |> isMatch [
+        Is "čeština"
+        Is "podstatné jméno"
+        Starts "skloňování"
+    ]
 
-    tryGetContent
-    >> Option.filter (hasChildPart "čeština")
-    >> Option.map (getChildPart "čeština")
-    >> Option.filter (hasChildPart "podstatné jméno")
-    >> Option.map (getChildPart "podstatné jméno")
-    >> Option.filter hasDeclension
-    >> Option.filter hasGender
-    >> Option.isSome
+    &&
+
+    word
+    |> ``match`` [
+        Is "čeština"
+        Is "podstatné jméno"
+    ] 
+    |> Option.exists (hasInfo (Starts "rod"))
 
 let isValidNoun word =
     word |> hasRequiredInfo &&

--- a/src/Core/Validation/VerbValidation.fs
+++ b/src/Core/Validation/VerbValidation.fs
@@ -3,28 +3,23 @@
 open Article
 open Archaisms
 
-let tryGetVerb =
-    tryGetContent
-    >> Option.filter (hasChildPart "čeština")
-    >> Option.map (getChildPart "čeština")
-    >> Option.filter (hasChildPart "sloveso")
-    >> Option.map (getChildPart "sloveso")
-
 let hasRequiredInfoParticiple = 
-    tryGetVerb
-    >> Option.exists (hasChildPart "časování")
+    isMatch [
+        Is "čeština"
+        Is "sloveso"
+        Is "časování"
+    ]
 
 let hasRequiredInfoImperative = 
-    let hasImperative = 
-        Option.filter (hasChildPart "časování")
-        >> Option.map (getChildPart "časování")
-        >> Option.map getTables
-        >> Option.map (Seq.map fst)
-        >> Option.map (Seq.contains "Rozkazovací způsob")
-        >> Option.contains true
-
-    tryGetVerb
-    >> hasImperative
+    ``match`` [
+        Is "čeština"
+        Is "sloveso"
+        Is "časování"
+    ]
+    >> Option.map getTables
+    >> Option.map (Seq.map fst)
+    >> Option.map (Seq.contains "Rozkazovací způsob")
+    >> Option.contains true
 
 let hasRequiredInfoConjugation = 
     tryGetVerb

--- a/src/Core/Validation/VerbValidation.fs
+++ b/src/Core/Validation/VerbValidation.fs
@@ -5,14 +5,12 @@ open Archaisms
 
 let hasRequiredInfoParticiple = 
     isMatch [
-        Is "čeština"
         Is "sloveso"
         Is "časování"
     ]
 
 let hasRequiredInfoImperative = 
     ``match`` [
-        Is "čeština"
         Is "sloveso"
         Is "časování"
     ]
@@ -23,7 +21,6 @@ let hasRequiredInfoImperative =
 
 let hasRequiredInfoConjugation = 
     isMatch [
-        Is "čeština"
         Is "sloveso"
         Is "časování"
     ]

--- a/src/Core/Validation/VerbValidation.fs
+++ b/src/Core/Validation/VerbValidation.fs
@@ -22,8 +22,11 @@ let hasRequiredInfoImperative =
     >> Option.contains true
 
 let hasRequiredInfoConjugation = 
-    tryGetVerb
-    >> Option.exists (hasChildPart "časování")
+    isMatch [
+        Is "čeština"
+        Is "sloveso"
+        Is "časování"
+    ]
 
 let isValidVerb = isModern
 

--- a/src/Server/Tasks/Verb.fs
+++ b/src/Server/Tasks/Verb.fs
@@ -7,8 +7,6 @@ open Microsoft.AspNetCore.Http
 open Tasks.Utils
 open Conjugation
 open Verb
-open Microsoft.Extensions.Logging
-open GrammarCategories
 
 let getVerbImperativesTask next (ctx : HttpContext) =
     task {

--- a/src/WikiParsing/Articles/AdjectiveArticle.fs
+++ b/src/WikiParsing/Articles/AdjectiveArticle.fs
@@ -34,9 +34,11 @@ let pluralDeclensionsMap =
            (3, getPluralVrchní) ]
 
 let getNumberOfDeclensions = 
-    getContent
-    >> getChildPart "čeština"
-    >> getParts "skloňování"
+    matches [
+        Is "čeština"
+        Any
+        Is "skloňování"
+    ]
     >> Seq.length
 
 let getPlural adjective = 

--- a/src/WikiParsing/Articles/AdjectiveArticle.fs
+++ b/src/WikiParsing/Articles/AdjectiveArticle.fs
@@ -35,7 +35,6 @@ let pluralDeclensionsMap =
 
 let getNumberOfDeclensions = 
     matches [
-        Is "čeština"
         Any
         Is "skloňování"
     ]

--- a/src/WikiParsing/Articles/Article.fs
+++ b/src/WikiParsing/Articles/Article.fs
@@ -42,7 +42,7 @@ let getContent =
 
 let tryGetContent word =
     try 
-        getContent word   
+        getContent word 
         |> Some 
     with | :? KeyNotFoundException | :? ArgumentException | :? WebException -> 
         None
@@ -193,12 +193,17 @@ let rec private getPartMatches parts (nodes: seq<HtmlNode>) =
         else 
             Seq.empty
 
-let ``match`` parts =
+let getCzechContent = 
     tryGetContent
+    >> Option.filter (hasPart "čeština")
+    >> Option.map (getPart "čeština")
+
+let ``match`` parts =
+    getCzechContent
     >> Option.bind (getPartMatch parts)
 
 let matches parts =
-    tryGetContent
+    getCzechContent
     >> Option.map (getPartMatches parts)
     >> Option.defaultValue Seq.empty
 

--- a/src/WikiParsing/Articles/NounArticle.fs
+++ b/src/WikiParsing/Articles/NounArticle.fs
@@ -11,7 +11,6 @@ type LockedArticle = HtmlProvider<"https://cs.wiktionary.org/wiki/debil">
 
 let getNumberOfDeclensions =
     matches [
-        Is "čeština"
         Is "podstatné jméno"
         Starts "skloňování"
     ]
@@ -51,14 +50,12 @@ let getLocked case number word =
 let getDeclinability word = 
     let hasIndeclinabilityMarkInNounSection = 
         ``match`` [
-            Is "čeština"
             Is "podstatné jméno"
         ] 
         >> Option.exists (hasInfo (Is "nesklonné"))
 
     let hasIndeclinabilityMarkInDeclensionSections =
         matches [
-            Is "čeština"
             Is "podstatné jméno"
             Starts "skloňování"
         ]
@@ -88,7 +85,6 @@ let getDeclension case number =
 
 let getGender =
     ``match`` [
-        Is "čeština"
         Is "podstatné jméno"
     ] 
     >> Option.map (getInfos (Starts "rod "))

--- a/src/WikiParsing/Articles/VerbArticle.fs
+++ b/src/WikiParsing/Articles/VerbArticle.fs
@@ -33,13 +33,21 @@ let getParticipleByTableIndex word n =
 
 let getWikiParticiples word =
     word
-    |> getContent
-    |> getChildPart "čeština"
-    |> getChildPart "sloveso"
-    |> getTables
-    |> Seq.map fst
-    |> Seq.findIndex ((=) "Příčestí")
-    |> getParticipleByTableIndex word
+    |> ``match`` [
+        Is "čeština"
+        Is "sloveso"
+    ]
+    |> Option.map getTables
+    |> Option.map (Seq.map fst)
+    |> Option.map (Seq.findIndex ((=) "Příčestí"))
+    |> Option.map (getParticipleByTableIndex word)
+    // TODO:
+    // There is a problem here: we couple this place
+    // with the fact that this is called after the verb validation
+    // where we check the existance of this table in the article.
+    // So logically we know that the table exists
+    // but code-wise we don't. This should be fixed.
+    |> Option.defaultWith (fun () -> failwith "odd word")
 
 let getParticiples = getWikiParticiples >> getForms
     

--- a/src/WikiParsing/Articles/VerbArticle.fs
+++ b/src/WikiParsing/Articles/VerbArticle.fs
@@ -2,7 +2,6 @@
 
 open FSharp.Data
 open WikiString
-open GrammarCategories
 open Conjugation
 open Article
 
@@ -34,7 +33,6 @@ let getParticipleByTableIndex word n =
 let getWikiParticiples word =
     word
     |> ``match`` [
-        Is "čeština"
         Is "sloveso"
     ]
     |> Option.map getTables

--- a/src/WikiParsing/Html.fs
+++ b/src/WikiParsing/Html.fs
@@ -13,10 +13,10 @@ type HtmlNode with
 
 let headerTags = [ "h1"; "h2"; "h3"; "h4"; "h5"; "h6" ]
 
-let getNodesByInnerText text =
+let getNodesByInnerText filter =
     Seq.collect  (fun (node: HtmlNode) -> node.Descendants())
     >> Seq.map   (fun node -> node, node.DirectInnerText())
-    >> Seq.where (fun (node, innerText) -> innerText.Contains text)
+    >> Seq.where (fun (node, innerText) -> filter innerText)
     >> Seq.distinctBy snd
     >> Seq.map fst
 

--- a/tests/WikiParsing.Tests/ArticleTests.fs
+++ b/tests/WikiParsing.Tests/ArticleTests.fs
@@ -138,7 +138,6 @@ let ``Detects no parts of speech``() =
 let ``Gets match``() =
     "panda"
     |> ``match`` [
-        Is "čeština"
         Is "podstatné jméno"
         Is "skloňování"
     ]
@@ -149,7 +148,6 @@ let ``Gets match``() =
 let ``Gets no match``() =
     "panda"
     |> ``match`` [
-        Is "čeština"
         Is "přídavné jméno"
         Is "skloňování"
     ]
@@ -159,7 +157,6 @@ let ``Gets no match``() =
 let ``Gets matches``() =
     "bus"
     |> matches [
-        Is "čeština"
         Starts "podstatné jméno"
     ]
     |> Seq.length
@@ -169,7 +166,6 @@ let ``Gets matches``() =
 let ``Gets no matches``() =
     "panda"
     |> matches [
-        Is "čeština"
         Is "přídavné jméno"
         Is "skloňování"
     ]
@@ -179,7 +175,6 @@ let ``Gets no matches``() =
 let ``Detects match``() =
     "čtvrt"
     |> isMatch [
-        Is "čeština"
         Is "podstatné jméno"
         Starts "skloňování"
     ]
@@ -189,7 +184,6 @@ let ``Detects match``() =
 let ``Detects no match``() =
     "bus"
     |> isMatch [
-        Is "čeština"
         Is "přídavné jméno"
         Is "skloňování"
     ]

--- a/tests/WikiParsing.Tests/ArticleTests.fs
+++ b/tests/WikiParsing.Tests/ArticleTests.fs
@@ -25,8 +25,8 @@ let ``Detects content``() =
 let ``Gets children parts``() =
     "ananas"
     |> getContent
-    |> getChildPart "čeština"
-    |> getChildrenParts
+    |> getPart "čeština"
+    |> getParts
     |> Seq.map fst
     |> seqEquals [ "výslovnost"; "dělení"; "podstatné jméno" ]
 
@@ -34,7 +34,7 @@ let ``Gets children parts``() =
 let ``Detects no children parts``() =
     "provozovat"
     |> getContent
-    |> getChildrenParts
+    |> getParts
     |> Seq.map fst
     |> seqEquals []
 
@@ -42,59 +42,59 @@ let ``Detects no children parts``() =
 let ``Detects child part``() =
     "panda"
     |> getContent
-    |> hasChildPart "čeština"
+    |> hasPart "čeština"
     |> Assert.True
 
 [<Fact>]
 let ``Detects no child part``() =
     "panda"
     |> getContent
-    |> hasChildPart "ruština"
+    |> hasPart "ruština"
     |> Assert.False
 
 [<Fact>]
 let ``Detects children parts - filter``() =
     "panda"
     |> getContent
-    |> hasChildrenPartsWhen ((=) "čeština")
+    |> hasPartsWhen ((=) "čeština")
     |> Assert.True
 
 [<Fact>]
 let ``Detects no children parts - filter``() =
     "panda"
     |> getContent
-    |> hasChildrenPartsWhen ((=) "ruština")
+    |> hasPartsWhen ((=) "ruština")
     |> Assert.False
 
 [<Fact>]
-let ``Gets info``() = 
+let ``Gets infos``() = 
     "panda"
     |> getContent
-    |> getChildPart "čeština"
-    |> getInfo "rod"
-    |> equals "rod ženský"
+    |> getPart "čeština"
+    |> getInfos (Starts "rod")
+    |> seqEquals ["rod ženský"]
 
 [<Fact>]
 let ``Detects info``() = 
     "mozek"
     |> getContent
-    |> hasInfo "chytrý"
+    |> hasInfo (Is "chytrý")
     |> Assert.True
 
 [<Fact>]
 let ``Detects no info``() = 
     "panda"
     |> getContent
-    |> hasInfo "evil"
+    |> hasInfo (Is "evil")
     |> Assert.False
 
 [<Fact>]
 let ``Gets tables``() =
     "musit"
     |> getContent
-    |> getChildPart "čeština"
-    |> getChildPart "sloveso"
-    |> getChildPart "časování"
+    |> getPart "čeština"
+    |> getPart "sloveso"
+    |> getPart "časování"
     |> getTables
     |> Seq.map fst
     |> seqEquals [ "Oznamovací způsob"; "Příčestí"; "Přechodníky" ]
@@ -103,9 +103,9 @@ let ``Gets tables``() =
 let ``Detects no tables``() =
     "musit"
     |> getContent
-    |> getChildPart "čeština"
-    |> getChildPart "sloveso"
-    |> getChildPart "význam"
+    |> getPart "čeština"
+    |> getPart "sloveso"
+    |> getPart "význam"
     |> getTables
     |> Seq.map fst
     |> seqEquals []
@@ -133,3 +133,64 @@ let ``Detects no parts of speech``() =
     "hello"
     |> getPartsOfSpeech
     |> seqEquals []
+
+[<Fact>]
+let ``Gets match``() =
+    "panda"
+    |> ``match`` [
+        Is "čeština"
+        Is "podstatné jméno"
+        Is "skloňování"
+    ]
+    |> Option.isSome
+    |> Assert.True
+
+[<Fact>]
+let ``Gets no match``() =
+    "panda"
+    |> ``match`` [
+        Is "čeština"
+        Is "přídavné jméno"
+        Is "skloňování"
+    ]
+    |> equals Option.None
+
+[<Fact>]
+let ``Gets matches``() =
+    "bus"
+    |> matches [
+        Is "čeština"
+        Starts "podstatné jméno"
+    ]
+    |> Seq.length
+    |> equals 2
+
+[<Fact>]
+let ``Gets no matches``() =
+    "panda"
+    |> matches [
+        Is "čeština"
+        Is "přídavné jméno"
+        Is "skloňování"
+    ]
+    |> Assert.Empty
+
+[<Fact>]
+let ``Detects match``() =
+    "čtvrt"
+    |> isMatch [
+        Is "čeština"
+        Is "podstatné jméno"
+        Starts "skloňování"
+    ]
+    |> Assert.True
+
+[<Fact>]
+let ``Detects no match``() =
+    "bus"
+    |> isMatch [
+        Is "čeština"
+        Is "přídavné jméno"
+        Is "skloňování"
+    ]
+    |> Assert.False


### PR DESCRIPTION
This is an attempt for a framework on top of the `Article` framework :D 

The API allows to easily go through Wikipedia article sections. I have tried various options, this is the best I could come up with for now. The API _match_, _matches_, _isMatch_ is inspired by the [Regex API](https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex?view=netframework-4.8#methods). 

I have tried extending the API so that we don't have to call `hasInfo` and `getInfo` methods of the `Article` module, but it brought more mess than value, partly because there are not enough occurrences to properly generalize the code. In the end, the `Article` framework got some recursion and some simplification of terms. I added some tests for the new methods as well. 

I would like to think this is the first take on the problem - once we identify other recurring patterns of using the Wiki article, we should extend the new API.

I added the two TODOs in the code - those are not created by these changes, it's rather that the changes exposed the problems we had already had in the code. I would like to address the issues separately. They also might go naturally if we decide to unite the tables for parts of speech.