### PR TITLE
Deployment updates due to changes in Azure internals

### DIFF
--- a/arm-template-appinsights.json
+++ b/arm-template-appinsights.json
@@ -14,6 +14,7 @@
     "northEuropeLocation": "northeurope",
     "brazilLocation": "latam-br-gru-edge",
     "pingTestName": "Ping",
+	"pingTestAlertName": "PingTestAlert",
     "webTest": "[concat('<WebTest         Name=\"Ping\"         Id=\"b0393e9f-a600-44a5-aa51-f4e476e1f035\"         Enabled=\"True\"         CssProjectStructure=\"\"         CssIteration=\"\"         Timeout=\"120\"         WorkItemIds=\"\"         xmlns=\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\"         Description=\"\"         CredentialUserName=\"\"         CredentialPassword=\"\"         PreAuthenticate=\"True\"         Proxy=\"default\"         StopOnError=\"False\"         RecordedResultFile=\"\"         ResultsLocale=\"\">        <Items>        <Request         Method=\"GET\"         Guid=\"aabc2a3e-4aca-b7cd-bc59-b3de14b18738\"         Version=\"1.1\"         Url=\"http://', parameters('appName'), '.azurewebsites.net\"         ThinkTime=\"0\"         Timeout=\"120\"         ParseDependentRequests=\"False\"         FollowRedirects=\"True\"         RecordResult=\"True\"         Cache=\"False\"         ResponseTimeGoal=\"0\"         Encoding=\"utf-8\"         ExpectedHttpStatusCode=\"200\"         ExpectedResponseUrl=\"\"         ReportingName=\"\"         IgnoreHttpStatusCode=\"False\" />        </Items>        </WebTest>')]"
   },
   "resources": [
@@ -48,7 +49,7 @@
       "type": "Microsoft.Insights/scheduledQueryRules",
       "name": "Exceptions",
       "apiVersion": "2018-04-16",
-      "location": "northeurope",
+      "location": "[variables('northEuropeLocation')]",
       "tags": {
         "[concat('hidden-link:/subscriptions/f400689a-038c-49be-a6ee-2d98e5000d90/resourcegroups/', parameters('appName'), '/providers/microsoft.insights/components/', variables('insights'))]": "Resource"
       },
@@ -86,7 +87,7 @@
       "type": "Microsoft.Insights/scheduledQueryRules",
       "name": "Requests",
       "apiVersion": "2018-04-16",
-      "location": "northeurope",
+      "location": "[variables('northEuropeLocation')]",
       "tags": {
         "[concat('hidden-link:/subscriptions/f400689a-038c-49be-a6ee-2d98e5000d90/resourcegroups/', parameters('appName'), '/providers/microsoft.insights/components/', variables('insights'))]": "Resource"
       },
@@ -122,63 +123,66 @@
     },
     {
       "type": "Microsoft.Insights/webtests",
-      "name": "PingTest",
-      "apiVersion": "2015-05-01",
-      "location": "northeurope",
-      "tags": {
-        "[concat('hidden-link:/subscriptions/f400689a-038c-49be-a6ee-2d98e5000d90/resourcegroups/', parameters('appName'), '/providers/microsoft.insights/components/', variables('insights'))]": "Resource"
+      "name": "[variables('pingTestName')]",
+      "apiVersion": "2014-04-01",
+      "location": "[variables('northEuropeLocation')]",
+	  "tags": {
+		"[concat('hidden-link:', resourceId('Microsoft.Insights/components', variables('insights')))]": "Resource"
       },
       "properties": {
-        "SyntheticMonitorId": "[uniqueString(variables('PingTestName'))]",
-        "Name": "[variables('PingTestName')]",
-        "Enabled": true,
-        "Frequency": 300,
-        "Timeout": 120,
-        "Kind": "ping",
-        "Locations": [
+        "syntheticMonitorId": "[variables('pingTestName')]",
+        "name": "[variables('pingTestName')]",
+        "enabled": true,
+        "frequency": 300,
+        "timeout": 120,
+        "kind": "ping",
+        "locations": [ 
           {
-            "Id": "[variables('brazilLocation')]"
+            "id": "[variables('brazilLocation')]"
           }
         ],
-        "Configuration": {
-          "WebTest": "[variables('webTest')]"
+        "configuration": {
+          "webTest": "[variables('webTest')]"
         }
       },
-      "dependsOn": [
+	  "dependsOn": [
         "[resourceId('microsoft.insights/components', variables('insights'))]"
       ]
     },
-    {
-      "type": "microsoft.insights/alertrules",
-      "name": "pingTestAlert",
-      "apiVersion": "2014-04-01",
-      "location": "North Europe",
+	{
+	  "type": "microsoft.insights/metricalerts",
+      "name": "[variables('pingTestAlertName')]",
+	  "apiVersion": "2018-03-01",
+	  "location": "global",
       "tags": {
-        "[concat('hidden-link:/subscriptions/f400689a-038c-49be-a6ee-2d98e5000d90/resourcegroups/', parameters('appName'), '/providers/microsoft.insights/components/', variables('insights'))]": "Resource",
-        "[concat('hidden-link:/subscriptions/f400689a-038c-49be-a6ee-2d98e5000d90/resourcegroups/', parameters('appName'), '/providers/microsoft.insights/webtests/', 'PingTest')]": "Resource"
+        "[concat('hidden-link:', resourceId('Microsoft.Insights/components', variables('insights')))]": "Resource",
+        "[concat('hidden-link:', resourceId('Microsoft.Insights/webtests', variables('pingTestName')))]": "Resource"
       },
-      "properties": {
-        "name": "PingTestAlertRule",
-        "isEnabled": true,
-        "condition": {
-          "odata.type": "Microsoft.Azure.Management.Insights.Models.LocationThresholdRuleCondition",
-          "dataSource": {
-            "odata.type": "Microsoft.Azure.Management.Insights.Models.RuleMetricDataSource",
-            "resourceUri": "[resourceId('microsoft.insights/webtests', 'PingTest')]",
-            "metricName": "GSMT_AvRaW"
-          },
-          "windowSize": "PT5M",
-          "failedLocationCount": 1
-        },
-        "action": {
-          "odata.type": "Microsoft.Azure.Management.Insights.Models.RuleEmailAction",
-          "sendToServiceOwners": true
-        }
-      },
-      "dependsOn": [
-        "[resourceId('microsoft.insights/webtests', 'PingTest')]"
-      ]
-    }
+	  "properties": {
+	    "severity": 0,
+	    "enabled": true,
+	    "scopes": [
+	  	  "[resourceId('Microsoft.Insights/webtests', variables('pingTestName'))]",
+	  	  "[resourceId('Microsoft.Insights/components', variables('insights'))]"
+	    ],
+	    "evaluationFrequency": "PT1M",
+	    "windowSize": "PT5M",
+	    "criteria": {
+	      "odata.type": "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria",
+	  	  "webTestId": "[resourceId('Microsoft.Insights/webtests', variables('pingTestName'))]",
+	  	  "componentId": "[resourceId('Microsoft.Insights/components', variables('insights'))]",
+	  	  "failedLocationCount": 1
+	    },
+	    "actions": [
+	  	  {
+	  	    "actionGroupId": "[resourceId('microsoft.insights/actionGroups', 'Email')]"
+	  	  }
+	    ]
+	  },
+	  "dependsOn": [
+	  	"[resourceId('microsoft.insights/webtests', variables('pingTestName'))]"
+	  ]
+	}
   ],
   "outputs": {
     "key": {

--- a/src/Server/Server.fsproj
+++ b/src/Server/Server.fsproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
       <OutputType>Exe</OutputType>
       <TargetFramework>netcoreapp3.0</TargetFramework>
+      <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
+      <AspNetCoreModuleName>AspNetCoreModule</AspNetCoreModuleName>
   </PropertyGroup>
 		<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
Microsoft [deprecated](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/monitoring-classic-retirement) classic App Service alerts (which we use to get emails about exceptions and failures in the service). That broke our deployment therefore we have to change our ARM template to deploy new generation alerts.

Also, starting with ASP .NET Core 2.2, IIS supports [in-process hosting model](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-3.1#in-process-hosting-model), which is kind of latest and greatest, and it looks like recently with some later 3.0.x version this is how the app tries to run by default. 

However, most probably due to our free tier limitations, we cannot run apps like this (thereby app just does not start) so we now need to [force](https://stackoverflow.com/questions/53811569/http-error-500-30-ancm-in-process-start-failure) web server to run how it used to. It took many hours to understand what's going on and I hope to come back to it to eventually enable in-process hosting model somehow but for now this at least saves our deployment.