### PR TITLE
Minor optimization of the Article framework

### DIFF
--- a/src/WikiParsing/Articles/Article.fs
+++ b/src/WikiParsing/Articles/Article.fs
@@ -139,9 +139,7 @@ let getPartsOfSpeech =
 
     getContent
     >> getPart "čeština"
-    >> Option.map getParts
-    >> Option.map (Seq.map fst)
-    >> Option.map (Seq.filter isPartOfSpeech)
+    >> Option.map (getParts >> Seq.map fst >> Seq.filter isPartOfSpeech)
     >> Option.defaultValue Seq.empty
 
 let getArticleName = 

--- a/tests/WikiParsing.Tests/ArticleTests.fs
+++ b/tests/WikiParsing.Tests/ArticleTests.fs
@@ -26,9 +26,9 @@ let ``Gets children parts``() =
     "ananas"
     |> getContent
     |> getPart "čeština"
-    |> getParts
-    |> Seq.map fst
-    |> seqEquals [ "výslovnost"; "dělení"; "podstatné jméno" ]
+    |> Option.map getParts
+    |> Option.map (Seq.map fst >> Seq.toList)
+    |> equals (Some [ "výslovnost"; "dělení"; "podstatné jméno" ])
 
 [<Fact>]
 let ``Detects no children parts``() =
@@ -42,14 +42,16 @@ let ``Detects no children parts``() =
 let ``Detects child part``() =
     "panda"
     |> getContent
-    |> hasPart "čeština"
+    |> getPart "čeština"
+    |> Option.isSome
     |> Assert.True
 
 [<Fact>]
 let ``Detects no child part``() =
     "panda"
     |> getContent
-    |> hasPart "ruština"
+    |> getPart "ruština"
+    |> Option.isSome
     |> Assert.False
 
 [<Fact>]
@@ -71,8 +73,8 @@ let ``Gets infos``() =
     "panda"
     |> getContent
     |> getPart "čeština"
-    |> getInfos (Starts "rod")
-    |> seqEquals ["rod ženský"]
+    |> Option.map (getInfos (Starts "rod") >> Seq.toList)
+    |> equals (Some ["rod ženský"])
 
 [<Fact>]
 let ``Detects info``() = 
@@ -93,22 +95,22 @@ let ``Gets tables``() =
     "musit"
     |> getContent
     |> getPart "čeština"
-    |> getPart "sloveso"
-    |> getPart "časování"
-    |> getTables
-    |> Seq.map fst
-    |> seqEquals [ "Oznamovací způsob"; "Příčestí"; "Přechodníky" ]
+    |> Option.bind (getPart "sloveso")
+    |> Option.bind (getPart "časování")
+    |> Option.map getTables
+    |> Option.map (Seq.map fst >> Seq.toList)
+    |> equals (Some [ "Oznamovací způsob"; "Příčestí"; "Přechodníky" ])
 
 [<Fact>]
 let ``Detects no tables``() =
     "musit"
     |> getContent
     |> getPart "čeština"
-    |> getPart "sloveso"
-    |> getPart "význam"
-    |> getTables
-    |> Seq.map fst
-    |> seqEquals []
+    |> Option.bind (getPart "sloveso")
+    |> Option.bind (getPart "význam")
+    |> Option.map getTables
+    |> Option.map (Seq.map fst >> Seq.toList)
+    |> equals (Some [])
 
 [<Fact>]
 let ``Detects non-locked article``() =


### PR DESCRIPTION
The idea is to one day make the framework robust and independent and decoupled from everything else here. For that, we should not assume that the framework functions are called in some specific order.

This is a small step in that direction - `getPart` function now returns an option therefore one does not have to call `hasPart` before it.

Tests are adjusted.