### PR TITLE
 Added the Rytmus pattern to masculine inanimates (#533)

### DIFF
--- a/src/Client/pages/NounAccusatives.fs
+++ b/src/Client/pages/NounAccusatives.fs
@@ -21,7 +21,7 @@ type Msg =
 
 let patterns =
     dict [ (MasculineAnimate, ["pán"; "muž"; "předseda"; "soudce"])
-           (MasculineInanimate, ["hrad"; "stroj"])
+           (MasculineInanimate, ["hrad"; "stroj"; "rytmus"])
            (Feminine, ["žena"; "růže"; "píseň"; "kost"])
            (Neuter, ["město"; "kuře"; "moře"; "stavení"; "drama"; "muzeum" ]) ]
 

--- a/src/Client/pages/NounPlurals.fs
+++ b/src/Client/pages/NounPlurals.fs
@@ -21,7 +21,7 @@ type Msg =
 
 let patterns =
     dict [ (MasculineAnimate, ["pán"; "muž"; "předseda"; "soudce"])
-           (MasculineInanimate, ["hrad"; "stroj"])
+           (MasculineInanimate, ["hrad"; "stroj"; "rytmus"])
            (Feminine, ["žena"; "růže"; "píseň"; "kost"])
            (Neuter, ["město"; "kuře"; "moře"; "stavení"; "drama"; "muzeum"]) ]
 

--- a/src/Core/Nouns/MasculineInanimateNounPatternDetector.fs
+++ b/src/Core/Nouns/MasculineInanimateNounPatternDetector.fs
@@ -4,17 +4,41 @@ open NounArticle
 open StringHelper
 open GrammarCategories
 
-let isPatternHrad = 
-    getDeclension Case.Genitive Number.Singular
-    >> Seq.exists (endsOneOf ["u"; "a"])
+let canBeLoanword = endsOneOf ["us"; "es"; "os"]
+
+let isPatternHrad = function
+    | noun when noun |> canBeLoanword -> 
+        let singulars = noun |> getDeclension Case.Nominative Number.Singular
+        let plurals = noun |> getDeclension Case.Nominative Number.Plural
+        
+        let isPluralPatternHrad (singular, plural) = 
+            singular |> append "y" = plural
+
+        Seq.allPairs singulars plurals |> Seq.exists isPluralPatternHrad
+    | noun ->
+        noun
+        |> getDeclension Case.Genitive Number.Singular
+        |> Seq.exists (endsOneOf ["u"; "a"])
 
 let isPatternStroj =
     getDeclension Case.Nominative Number.Plural
     >> Seq.exists (endsOneOf ["e"; "ě"])
 
+let isPatternRytmus noun =
+    noun |> canBeLoanword && 
+
+    let singulars = noun |> getDeclension Case.Nominative Number.Singular
+    let plurals = noun |> getDeclension Case.Nominative Number.Plural
+
+    let isPluralPatternRytmus (singular, plural) = 
+        singular |> removeLast 2 |> append "y" = plural
+
+    Seq.allPairs singulars plurals |> Seq.exists isPluralPatternRytmus
+
 let patternDetectors = [
     (isPatternHrad, "hrad")
     (isPatternStroj, "stroj")
+    (isPatternRytmus, "rytmus")
 ]
 
 let isPattern word patternDetector = fst patternDetector word

--- a/tests/Core.IntegrationTests/MasculineInanimateNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/MasculineInanimateNounPatternDetectorTests.fs
@@ -6,7 +6,7 @@ open MasculineInanimateNounPatternDetector
 [<Theory>]
 [<InlineData "strom">]
 [<InlineData "leden">]
-[<InlineData "ateizmus">]
+[<InlineData "bonus">]
 [<InlineData "game">]
 [<InlineData "hardware">]
 [<InlineData "hemenex">]
@@ -22,6 +22,7 @@ let ``Detects pattern hrad`` word =
 [<InlineData "konec">]
 [<InlineData "déšť">]
 [<InlineData "hokej">]
+[<InlineData "kosmos">]
 let ``Detects not pattern hrad`` word =
     word
     |> isPatternHrad
@@ -41,15 +42,37 @@ let ``Detects pattern stroj`` word =
 [<InlineData "týl">]
 [<InlineData "leden">]
 [<InlineData "hřeben">]
+[<InlineData "kosmos">]
 let ``Detects not pattern stroj`` word =
     word
     |> isPatternStroj
     |> Assert.False
 
 [<Theory>]
+[<InlineData "eukalyptus">]
+[<InlineData "diabetes">]
+[<InlineData "kosmos">]
+let ``Detects pattern rytmus`` word =
+    word
+    |> isPatternRytmus
+    |> Assert.True
+
+[<Theory>]
+[<InlineData "bonus">]
+[<InlineData "chaos">]
+[<InlineData "rádius">]
+[<InlineData "hrad">]
+[<InlineData "stroj">]
+let ``Detects not pattern rytmus`` word =
+    word
+    |> isPatternRytmus
+    |> Assert.False
+
+[<Theory>]
 [<InlineData "rubl">]
 [<InlineData "plevel">]
 [<InlineData "hospic">]
+[<InlineData "glóbus">]
 let ``Detects multiple patterns`` word =
     word
     |> getPatterns


### PR DESCRIPTION
[This pattern](http://prirucka.ujc.cas.cz/?slovo=rytmus#nadpis2_3) is more complicated to detect than others. The pattern addresses imported words (from Latin or Greek) ending with "us", "es", "os". But words ending like that can be either just Czech (_nos_, _les_) or completely "czechified" and following "hrad" pattern despite their origin (_bonus_, _citrus_). 

Other words (e.g. _glóbus_) allow multiple declensions, by "hrad" and by "rytmus".