### PR TITLE
Optimized Wiktionary access with more robust domain model (#632)

### DIFF
--- a/src/Common/Common.fsproj
+++ b/src/Common/Common.fsproj
@@ -11,6 +11,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="WikiArticles.fs" />
     <Compile Include="GrammarCategories.fs" />
     <Compile Include="Conjugation.fs" />
     <Compile Include="SequenceExtensions.fs" />

--- a/src/Common/WikiArticles.fs
+++ b/src/Common/WikiArticles.fs
@@ -1,0 +1,19 @@
+﻿module WikiArticles
+
+type Article = {
+    Title: string
+    Text: string 
+}
+
+type NounArticle = NounArticle of Article
+type NounArticleWithPlural = NounArticleWithPlural of NounArticle
+type NounArticleWithAccusative = NounArticleWithAccusative of NounArticle
+
+type AdjectiveArticle = AdjectiveArticle of Article
+type AdjectiveArticleWithPlural = AdjectiveArticleWithPlural of AdjectiveArticle
+type AdjectiveArticleWithComparative = AdjectiveArticleWithComparative of AdjectiveArticle
+
+type VerbArticle = VerbArticle of Article
+type VerbArticleWithImperative = VerbArticleWithImperative of VerbArticle
+type VerbArticleWithParticiple = VerbArticleWithParticiple of VerbArticle
+type VerbArticleWithConjugation = VerbArticleWithConjugation of VerbArticle

--- a/src/Core/Adjectives/Adjective.fs
+++ b/src/Core/Adjectives/Adjective.fs
@@ -1,12 +1,16 @@
 ﻿module Adjective
 
-let getPlural = 
+open WikiArticles
+
+let getPlural =
     AdjectiveArticle.getPlural
 
 let getComparatives = 
     AdjectiveArticle.getComparatives
 
-let hasRegularComparative word =
+let hasRegularComparative article =
+    let (AdjectiveArticleWithComparative (AdjectiveArticle { Title = word })) = article
+
     let theoretical = ComparativeBuilder.buildComparative word
-    let practical = getComparatives word
+    let practical = getComparatives article
     practical |> Array.contains theoretical

--- a/src/Core/Nouns/FeminineNounPatternDetector.fs
+++ b/src/Core/Nouns/FeminineNounPatternDetector.fs
@@ -4,30 +4,30 @@ open NounArticle
 open StringHelper
 open GrammarCategories
 
-let isPatternŽena word = 
-    let nominatives = word |> getDeclension Case.Nominative Number.Singular
-    let genitives = word |> getDeclension Case.Genitive Number.Singular
+let isPatternŽena article = 
+    let nominatives = article |> getDeclension Case.Nominative Number.Singular
+    let genitives = article |> getDeclension Case.Genitive Number.Singular
 
     nominatives |> Seq.exists (ends "a") && 
     genitives |> Seq.exists (endsOneOf ["y"; "i"])
 
-let isPatternRůže word =
-    let nominatives = word |> getDeclension Case.Nominative Number.Singular
-    let genitives = word |> getDeclension Case.Genitive Number.Singular
+let isPatternRůže article =
+    let nominatives = article |> getDeclension Case.Nominative Number.Singular
+    let genitives = article |> getDeclension Case.Genitive Number.Singular
 
     nominatives |> Seq.exists (endsOneOf ["e"; "ě"; "a"]) && 
     genitives |> Seq.exists (endsOneOf ["e"; "ě"])
 
-let isPatternPíseň word =
-    let nominatives = word |> getDeclension Case.Nominative Number.Singular
-    let genitives = word |> getDeclension Case.Genitive Number.Singular
+let isPatternPíseň article =
+    let nominatives = article |> getDeclension Case.Nominative Number.Singular
+    let genitives = article |> getDeclension Case.Genitive Number.Singular
 
     nominatives |> Seq.exists Stem.endsConsonant &&
     genitives |> Seq.exists (endsOneOf ["e"; "ě"])
 
-let isPatternKost word =
-    let datives = word |> getDeclension Case.Dative Number.Plural
-    let instrumentals = word |> getDeclension Case.Instrumental Number.Plural
+let isPatternKost article =
+    let datives = article |> getDeclension Case.Dative Number.Plural
+    let instrumentals = article |> getDeclension Case.Instrumental Number.Plural
 
     datives |> Seq.exists (ends "em") &&
     instrumentals |> Seq.exists (not << endsOneOf ["emi"; "ěmi"])
@@ -39,9 +39,9 @@ let patternDetectors = [
     (isPatternKost, "kost")
 ]
 
-let isPattern word patternDetector = fst patternDetector word
+let isPattern article patternDetector = fst patternDetector article
 
-let getPatterns word = 
+let getPatterns article = 
     patternDetectors
-    |> Seq.where (isPattern word)
+    |> Seq.where (isPattern article)
     |> Seq.map snd

--- a/src/Core/Nouns/MasculineAnimateNounPatternDetector.fs
+++ b/src/Core/Nouns/MasculineAnimateNounPatternDetector.fs
@@ -8,9 +8,9 @@ let isPatternPán =
     getDeclension Case.Genitive Number.Singular
     >> Seq.exists (ends "a")
 
-let isPatternMuž noun =
-    let nominatives = noun |> getDeclension Case.Nominative Number.Singular
-    let genitives = noun |> getDeclension Case.Genitive Number.Singular
+let isPatternMuž article =
+    let nominatives = article |> getDeclension Case.Nominative Number.Singular
+    let genitives = article |> getDeclension Case.Genitive Number.Singular
 
     nominatives |> Seq.exists (Stem.endsSoft) &&
     genitives |> Seq.exists (endsOneOf ["e"; "ě"])
@@ -30,9 +30,9 @@ let patternDetectors = [
     (isPatternSoudce, "soudce")
 ]
 
-let isPattern word patternDetector = fst patternDetector word
+let isPattern article patternDetector = fst patternDetector article
 
-let getPatterns word = 
+let getPatterns article = 
     patternDetectors
-    |> Seq.where (isPattern word)
+    |> Seq.where (isPattern article)
     |> Seq.map snd

--- a/src/Core/Nouns/MasculineInanimateNounPatternDetector.fs
+++ b/src/Core/Nouns/MasculineInanimateNounPatternDetector.fs
@@ -3,20 +3,23 @@
 open NounArticle
 open StringHelper
 open GrammarCategories
+open WikiArticles
 
 let canBeLoanword = endsOneOf ["us"; "es"; "os"]
 
-let isPatternHrad = function
-    | noun when noun |> canBeLoanword -> 
-        let singulars = noun |> getDeclension Case.Nominative Number.Singular
-        let plurals = noun |> getDeclension Case.Nominative Number.Plural
+let isPatternHrad article = 
+    let (NounArticle { Title = noun }) = article
+    match article with
+    | article when noun |> canBeLoanword -> 
+        let singulars = article |> getDeclension Case.Nominative Number.Singular
+        let plurals = article |> getDeclension Case.Nominative Number.Plural
         
         let isPluralPatternHrad (singular, plural) = 
             singular |> append "y" = plural
 
         Seq.allPairs singulars plurals |> Seq.exists isPluralPatternHrad
-    | noun ->
-        noun
+    | article ->
+        article
         |> getDeclension Case.Genitive Number.Singular
         |> Seq.exists (endsOneOf ["u"; "a"])
 
@@ -24,11 +27,13 @@ let isPatternStroj =
     getDeclension Case.Nominative Number.Plural
     >> Seq.exists (endsOneOf ["e"; "ě"])
 
-let isPatternRytmus noun =
+let isPatternRytmus article =
+    let (NounArticle { Title = noun }) = article
+
     noun |> canBeLoanword && 
 
-    let singulars = noun |> getDeclension Case.Nominative Number.Singular
-    let plurals = noun |> getDeclension Case.Nominative Number.Plural
+    let singulars = article |> getDeclension Case.Nominative Number.Singular
+    let plurals = article |> getDeclension Case.Nominative Number.Plural
 
     let isPluralPatternRytmus (singular, plural) = 
         singular |> removeLast 2 |> append "y" = plural
@@ -41,9 +46,9 @@ let patternDetectors = [
     (isPatternRytmus, "rytmus")
 ]
 
-let isPattern word patternDetector = fst patternDetector word
+let isPattern article patternDetector = fst patternDetector article
 
-let getPatterns word = 
+let getPatterns article = 
     patternDetectors
-    |> Seq.where (isPattern word)
+    |> Seq.where (isPattern article)
     |> Seq.map snd

--- a/src/Core/Nouns/NeuterNounPatternDetector.fs
+++ b/src/Core/Nouns/NeuterNounPatternDetector.fs
@@ -5,16 +5,16 @@ open StringHelper
 open GrammarCategories
 open Letters
 
-let isPatternMěsto word = 
-    let nominatives = word |> getDeclension Case.Nominative Number.Singular
-    let genitives = word |> getDeclension Case.Genitive Number.Plural
+let isPatternMěsto article = 
+    let nominatives = article |> getDeclension Case.Nominative Number.Singular
+    let genitives = article |> getDeclension Case.Genitive Number.Plural
     
     nominatives |> Seq.exists (ends "o") &&
     genitives |> Seq.exists (Stem.endsConsonant)
 
-let isPatternMoře word =
-    let singulars = word |> getDeclension Case.Nominative Number.Singular
-    let plurals = word |> getDeclension Case.Nominative Number.Plural
+let isPatternMoře article =
+    let singulars = article |> getDeclension Case.Nominative Number.Singular
+    let plurals = article |> getDeclension Case.Nominative Number.Plural
 
     singulars |> Seq.exists (endsOneOf ["e"; "ě"]) &&
     plurals |> Seq.exists (endsOneOf ["e"; "ě"])
@@ -23,25 +23,25 @@ let isPatternStavení =
     getDeclension Case.Genitive Number.Singular
     >> Seq.exists (ends "í")
 
-let isPatternKuře word =
-    let singulars = word |> getDeclension Case.Nominative Number.Singular
-    let plurals = word |> getDeclension Case.Nominative Number.Plural
+let isPatternKuře article =
+    let singulars = article |> getDeclension Case.Nominative Number.Singular
+    let plurals = article |> getDeclension Case.Nominative Number.Plural
 
     singulars |> Seq.exists (endsOneOf ["e"; "ě"]) &&
     plurals |> Seq.exists (ends "ata")
 
-let isPatternDrama word =
-    let singulars = word |> getDeclension Case.Nominative Number.Singular
-    let plurals = word |> getDeclension Case.Nominative Number.Plural
+let isPatternDrama article =
+    let singulars = article |> getDeclension Case.Nominative Number.Singular
+    let plurals = article |> getDeclension Case.Nominative Number.Plural
 
     singulars |> Seq.exists (ends "ma") &&
     plurals |> Seq.exists (ends "mata")
 
-let isPatternMuzeum word =
+let isPatternMuzeum article =
     let stemEndsVowel = remove "um" >> Seq.last >> isVowel
     let rule word = word |> ends "um" && word |> stemEndsVowel
 
-    let singulars = word |> getDeclension Case.Nominative Number.Singular
+    let singulars = article |> getDeclension Case.Nominative Number.Singular
     singulars |> Seq.exists rule
 
 let patternDetectors = [
@@ -53,9 +53,9 @@ let patternDetectors = [
     (isPatternMuzeum, "muzeum")
 ]
 
-let isPattern word patternDetector = fst patternDetector word
+let isPattern article patternDetector = fst patternDetector article
 
-let getPatterns word = 
+let getPatterns article = 
     patternDetectors
-    |> Seq.where (isPattern word)
+    |> Seq.where (isPattern article)
     |> Seq.map snd

--- a/src/Core/Nouns/NounPatterns.fs
+++ b/src/Core/Nouns/NounPatterns.fs
@@ -12,13 +12,13 @@ let patternsGenderMap =
 
 let getPatternsByGender word gender = patternsGenderMap.[gender] word
 
-let getPatterns noun = 
-    match noun |> getDeclinability with
+let getPatterns article = 
+    match article |> getDeclinability with
     | Indeclinable ->
         Seq.empty
     | Declinable ->
-        noun
+        article
         |> getGender
         |> Option.map fromString
-        |> Option.map (getPatternsByGender noun)
+        |> Option.map (getPatternsByGender article)
         |> Option.defaultValue Seq.empty

--- a/src/Core/Validation/AdjectiveValidation.fs
+++ b/src/Core/Validation/AdjectiveValidation.fs
@@ -4,9 +4,10 @@ open Article
 open AdjectiveArticle
 open Comparison
 open ComparativeBuilder
+open WikiArticles
 
 let hasMorphologicalComparatives = 
-    getComparatives 
+    getComparatives
     >> Array.filter isMorphologicalComparison
     >> (not << Seq.isEmpty)
 
@@ -24,12 +25,19 @@ let hasRequiredInfoPlural =
 
 let isValidAdjective = isPositive
 
-let isComparativeValid word = 
-    word |> isValidAdjective &&
-    word |> hasRequiredInfoComparative &&
-    word |> hasMorphologicalComparatives &&
-    word |> canBuildComparative
+let parseAdjective article = 
+    if article.Title |> isValidAdjective
+    then Some (AdjectiveArticle article)
+    else None
 
-let isPluralValid word = 
-    word |> isValidAdjective &&
-    word |> hasRequiredInfoPlural
+let parseAdjectiveComparative =
+    parseAdjective
+    >> Option.filter (fun (AdjectiveArticle article) -> hasRequiredInfoComparative article)
+    >> Option.filter (AdjectiveArticleWithComparative >> hasMorphologicalComparatives)
+    >> Option.filter (fun (AdjectiveArticle { Title = title }) -> canBuildComparative title)
+    >> Option.map AdjectiveArticleWithComparative
+
+let parseAdjectivePlural =
+    parseAdjective
+    >> Option.filter (fun (AdjectiveArticle article) -> hasRequiredInfoPlural article)
+    >> Option.map AdjectiveArticleWithPlural

--- a/src/Core/Validation/VerbValidation.fs
+++ b/src/Core/Validation/VerbValidation.fs
@@ -2,6 +2,7 @@
 
 open Article
 open Archaisms
+open WikiArticles
 
 let hasRequiredInfoParticiple = 
     isMatch [
@@ -27,14 +28,22 @@ let hasRequiredInfoConjugation =
 
 let isValidVerb = isModern
 
-let isParticipleValid word = 
-    word |> isValidVerb &&
-    word |> hasRequiredInfoParticiple
+let parseVerb article =
+   if article.Title |> isValidVerb
+   then Some (VerbArticle article)
+   else None
 
-let isImperativeValid word =
-    word |> isValidVerb &&
-    word |> hasRequiredInfoImperative
+let parseVerbImperative =
+    parseVerb
+    >> Option.filter (fun (VerbArticle article) -> hasRequiredInfoImperative article)
+    >> Option.map VerbArticleWithImperative
 
-let isConjugationValid word =
-    word |> isValidVerb &&
-    word |> hasRequiredInfoConjugation
+let parseVerbParticiple =
+    parseVerb
+    >> Option.filter (fun (VerbArticle article) -> hasRequiredInfoParticiple article)
+    >> Option.map VerbArticleWithParticiple
+
+let parseVerbConjugation = 
+    parseVerb
+    >> Option.filter (fun (VerbArticle article) -> hasRequiredInfoConjugation article)
+    >> Option.map VerbArticleWithConjugation

--- a/src/Core/Verbs/Verb.fs
+++ b/src/Core/Verbs/Verb.fs
@@ -1,5 +1,7 @@
 ﻿module Verb
 
+open WikiArticles
+
 let getClass = 
     VerbArticle.getThirdPersonSingular
     >> Seq.tryExactlyOne
@@ -18,10 +20,12 @@ let getParticiples =
 let getConjugation = 
     VerbArticle.getConjugation
 
-let hasRegularParticiple word = 
-    let theoretical = ParticipleBuilder.buildParticiple word
-    let practical = getParticiples word
+let hasRegularParticiple article = 
+    let (VerbArticleWithParticiple (VerbArticle { Title = verb })) = article
+
+    let theoretical = ParticipleBuilder.buildParticiple verb
+    let practical = getParticiples article
     practical |> Array.contains theoretical
 
-let getParticiplePattern = 
-    ParticiplePatternDetector.getPattern
+let getParticiplePattern (VerbArticle ({ Title = verb })) = 
+    ParticiplePatternDetector.getPattern verb

--- a/src/Core/Verbs/VerbPatternDetector.fs
+++ b/src/Core/Verbs/VerbPatternDetector.fs
@@ -6,6 +6,7 @@ open Stem
 open Reflexives
 open VerbClasses
 open VerbArticle
+open WikiArticles
 
 let isPatternTisknoutNonReflexive word = 
     let getStem = removeLast 4
@@ -84,8 +85,10 @@ let patternClassMap =
 
 let getPatternByClass verb verbClass = patternClassMap.[verbClass] verb
 
-let getPattern verb = 
-    verb
+let getPattern article = 
+    let (VerbArticle { Title = verb }) = article
+
+    article
     |> getThirdPersonSingular
     |> Seq.tryExactlyOne
     |> Option.map removeReflexive

--- a/src/Scraper/Word.fs
+++ b/src/Scraper/Word.fs
@@ -2,40 +2,60 @@
 
 open Article
 
-let recordCzechPartOfSpeech word = function
+let recordCzechPartOfSpeech article = function
     | "podstatné jméno" -> [
-        if word |> NounValidation.isPluralValid
-        then word |> NounRegistration.registerNounPlural
+        article
+        |> NounValidation.parseNounPlural
+        |> Option.map NounRegistration.registerNounPlural
+        |> Option.defaultValue (async { return () })
 
-        if word |> NounValidation.isAccusativeValid
-        then word |> NounRegistration.registerNounAccusative
+        article
+        |> NounValidation.parseNounAccusative
+        |> Option.map NounRegistration.registerNounAccusative
+        |> Option.defaultValue (async { return () })
       ]
 
     | "přídavné jméno" -> [
-        if word |> AdjectiveValidation.isPluralValid
-        then word |> AdjectiveRegistration.registerAdjectivePlural
+        article 
+        |> AdjectiveValidation.parseAdjectivePlural
+        |> Option.map AdjectiveRegistration.registerAdjectivePlural
+        |> Option.defaultValue (async { return () })
 
-        if word |> AdjectiveValidation.isComparativeValid
-        then word |> AdjectiveRegistration.registerAdjectiveComparative
+        article 
+        |> AdjectiveValidation.parseAdjectiveComparative
+        |> Option.map AdjectiveRegistration.registerAdjectiveComparative
+        |> Option.defaultValue (async { return () })
       ]
             
     | "sloveso" -> [
-        if word |> VerbValidation.isImperativeValid
-        then word |> VerbRegistration.registerVerbImperative
+        article
+        |> VerbValidation.parseVerbImperative
+        |> Option.map VerbRegistration.registerVerbImperative
+        |> Option.defaultValue (async { return () })
 
-        if word |> VerbValidation.isParticipleValid
-        then word |> VerbRegistration.registerVerbParticiple
+        article
+        |> VerbValidation.parseVerbParticiple
+        |> Option.map VerbRegistration.registerVerbParticiple
+        |> Option.defaultValue (async { return () })
 
-        if word |> VerbValidation.isConjugationValid
-        then word |> VerbRegistration.registerVerbConjugation
+        article
+        |> VerbValidation.parseVerbConjugation
+        |> Option.map VerbRegistration.registerVerbConjugation
+        |> Option.defaultValue (async { return () })
       ]
 
     | _ -> []
     
+let getTasks article = 
+    article 
+    |> getPartsOfSpeech 
+    |> Seq.collect (recordCzechPartOfSpeech article)
+
 let record word =
     word
-    |> getPartsOfSpeech
-    |> Seq.collect (recordCzechPartOfSpeech word)
+    |> getArticle
+    |> Option.map getTasks
+    |> Option.defaultValue Seq.empty
     |> Async.Parallel
     |> Async.Ignore
     |> Async.RunSynchronously

--- a/src/Scraper/Word.fs
+++ b/src/Scraper/Word.fs
@@ -2,46 +2,28 @@
 
 open Article
 
+let noOperationAsync = async { return () }
+
+let registerIfValid parse register = 
+    parse
+    >> Option.map register 
+    >> Option.defaultValue noOperationAsync
+
 let recordCzechPartOfSpeech article = function
     | "podstatné jméno" -> [
-        article
-        |> NounValidation.parseNounPlural
-        |> Option.map NounRegistration.registerNounPlural
-        |> Option.defaultValue (async { return () })
-
-        article
-        |> NounValidation.parseNounAccusative
-        |> Option.map NounRegistration.registerNounAccusative
-        |> Option.defaultValue (async { return () })
+        article |> registerIfValid NounValidation.parseNounPlural NounRegistration.registerNounPlural
+        article |> registerIfValid NounValidation.parseNounAccusative NounRegistration.registerNounAccusative
       ]
 
     | "přídavné jméno" -> [
-        article 
-        |> AdjectiveValidation.parseAdjectivePlural
-        |> Option.map AdjectiveRegistration.registerAdjectivePlural
-        |> Option.defaultValue (async { return () })
-
-        article 
-        |> AdjectiveValidation.parseAdjectiveComparative
-        |> Option.map AdjectiveRegistration.registerAdjectiveComparative
-        |> Option.defaultValue (async { return () })
+        article |> registerIfValid AdjectiveValidation.parseAdjectivePlural AdjectiveRegistration.registerAdjectivePlural
+        article |> registerIfValid AdjectiveValidation.parseAdjectiveComparative AdjectiveRegistration.registerAdjectiveComparative
       ]
             
     | "sloveso" -> [
-        article
-        |> VerbValidation.parseVerbImperative
-        |> Option.map VerbRegistration.registerVerbImperative
-        |> Option.defaultValue (async { return () })
-
-        article
-        |> VerbValidation.parseVerbParticiple
-        |> Option.map VerbRegistration.registerVerbParticiple
-        |> Option.defaultValue (async { return () })
-
-        article
-        |> VerbValidation.parseVerbConjugation
-        |> Option.map VerbRegistration.registerVerbConjugation
-        |> Option.defaultValue (async { return () })
+        article |> registerIfValid VerbValidation.parseVerbImperative VerbRegistration.registerVerbImperative
+        article |> registerIfValid VerbValidation.parseVerbParticiple VerbRegistration.registerVerbParticiple
+        article |> registerIfValid VerbValidation.parseVerbConjugation VerbRegistration.registerVerbConjugation
       ]
 
     | _ -> []

--- a/src/Scraper/WordRegistration/AdjectiveRegistration.fs
+++ b/src/Scraper/WordRegistration/AdjectiveRegistration.fs
@@ -2,18 +2,25 @@
 
 open Storage
 open Adjective
+open WikiArticles
 
-let registerAdjectivePlural word =
-    let singular = word |> map id serializeObject ""
-    let plural = word |> map getPlural serializeObject ""
+let registerAdjectivePlural adjectiveArticleWithPlural =
+    let (AdjectiveArticleWithPlural adjectiveArticle) = adjectiveArticleWithPlural
+    let (AdjectiveArticle { Title = word }) = adjectiveArticle
+
+    let singular = word |> serializeObject
+    let plural = adjectiveArticleWithPlural |> getPlural |> serializeObject
 
     AdjectivePlural.AdjectivePlural(word, singular, plural)
     |> upsert "adjectiveplurals"
 
-let registerAdjectiveComparative word =
-    let positive = word |> map id serializeObject ""
-    let comparatives = word |> map getComparatives serializeObject ""
-    let isRegular = word |> map hasRegularComparative id false
+let registerAdjectiveComparative adjectiveArticleWithComparative =
+    let (AdjectiveArticleWithComparative adjectiveArticle) = adjectiveArticleWithComparative
+    let (AdjectiveArticle { Title = word }) = adjectiveArticle
+
+    let positive = word |> serializeObject
+    let comparatives = adjectiveArticleWithComparative |> getComparatives |> serializeObject
+    let isRegular = adjectiveArticleWithComparative |> hasRegularComparative
 
     AdjectiveComparative.AdjectiveComparative(word, positive, comparatives, isRegular)
     |> upsert "adjectivecomparatives"

--- a/src/Scraper/WordRegistration/NounRegistration.fs
+++ b/src/Scraper/WordRegistration/NounRegistration.fs
@@ -3,20 +3,28 @@
 open Storage
 open Noun
 open GrammarCategories
+open WikiArticles
 
-let registerNounPlural word =
-    let singular = word |> map id serializeObject ""
-    let plurals = word |> map (getDeclension Case.Nominative Number.Plural) serializeObject ""
-    let gender = word |> map getGender serializeOption<Gender> ""
-    let patterns = word |> map getPatterns serializeObject ""
+let registerNounPlural nounArticleWithPlural =
+    let (NounArticleWithPlural nounArticle) = nounArticleWithPlural
+    let (NounArticle { Title = word }) = nounArticle
+
+    let singular = word |> serializeObject
+    let plurals = nounArticle |> getDeclension Case.Nominative Number.Plural |> serializeObject
+    let gender = nounArticle |> getGender |> serializeOption<Gender>
+    let patterns = nounArticle |> getPatterns |> serializeObject
 
     NounPlural.NounPlural(word, singular, plurals, gender, patterns)
     |> upsert "nounplurals"
 
-let registerNounAccusative word =
-    let nominative = word |> map id serializeObject ""
-    let accusatives = word |> map (getDeclension Case.Accusative Number.Singular) serializeObject ""
-    let gender = word |> map getGender serializeOption<Gender> ""
-    let patterns = word |> map getPatterns serializeObject ""
+let registerNounAccusative nounArticleWithAccusative =
+    let (NounArticleWithAccusative nounArticle) = nounArticleWithAccusative
+    let (NounArticle { Title = word }) = nounArticle
+
+    let nominative = word |> serializeObject
+    let accusatives = nounArticle |> getDeclension Case.Accusative Number.Singular |> serializeObject
+    let gender = nounArticle |> getGender |> serializeOption<Gender>
+    let patterns = nounArticle |> getPatterns |> serializeObject
+
     NounAccusative.NounAccusative(word, nominative, accusatives, gender, patterns)
     |> upsert "nounaccusatives"

--- a/src/Scraper/WordRegistration/VerbRegistration.fs
+++ b/src/Scraper/WordRegistration/VerbRegistration.fs
@@ -4,36 +4,47 @@ open Storage
 open Verb
 open VerbClasses
 open Conjugation
+open WikiArticles
 
-let registerVerbImperative word =
-    let indicative = word |> map id serializeObject ""
-    let imperatives = word |> map getImperatives serializeObject ""
-    let ``class`` = word |> map getClass serializeOption<VerbClass> ""
-    let pattern = word |> map getImperativePattern serializeOption<string> ""
+let registerVerbImperative verbArticleWithImperative =
+    let (VerbArticleWithImperative verbArticle) = verbArticleWithImperative
+    let (VerbArticle { Title = word }) = verbArticle
+
+    let indicative = word |> serializeObject
+    let imperatives = verbArticleWithImperative |> getImperatives |> serializeObject
+    let ``class`` = verbArticle |> getClass |> serializeOption<VerbClass>
+    let pattern = verbArticle |> getImperativePattern |> serializeOption<string>
 
     VerbImperative.VerbImperative(word, indicative, imperatives, ``class``, pattern)
     |> upsert "verbimperatives"
 
-let registerVerbParticiple word = 
-    let infinitive = word |> map id serializeObject ""
-    let participles = word |> map getParticiples serializeObject ""
-    let pattern = word |> map getParticiplePattern serializeString ""
-    let isRegular = word |> map hasRegularParticiple id false
+let registerVerbParticiple verbArticleWithParticiple = 
+    let (VerbArticleWithParticiple verbArticle) = verbArticleWithParticiple
+    let (VerbArticle { Title = word }) = verbArticle
+
+    let wordId = word
+    let infinitive = word |> serializeObject
+    let participles = verbArticleWithParticiple |> getParticiples |> serializeObject
+    let pattern = verbArticle |> getParticiplePattern |> serializeString
+    let isRegular = verbArticleWithParticiple |> hasRegularParticiple
 
     VerbParticiple.VerbParticiple(word, infinitive, participles, pattern, isRegular)
     |> upsert "verbparticiples"
 
-let registerVerbConjugation word =
-    let infinitive = word |> map id serializeObject ""
-    let pattern = word |> map getParticiplePattern serializeString ""
+let registerVerbConjugation verbConjugationArticle =
+    let (VerbArticleWithConjugation verbArticle) = verbConjugationArticle
+    let (VerbArticle { Title = word }) = verbArticle
 
-    let getConjugation case = map (getConjugation case) serializeObject ""
-    let firstSingular = word |> getConjugation FirstSingular
-    let secondSingular = word |> getConjugation SecondSingular
-    let thirdSingular = word |> getConjugation ThirdSingular
-    let firstPlural = word |> getConjugation FirstPlural
-    let secondPlural = word |> getConjugation SecondPlural
-    let thirdPlural = word |> getConjugation ThirdPlural
+    let infinitive = word |> serializeObject
+    let pattern = verbArticle |> getParticiplePattern |> serializeString
+
+    let getConjugation case = getConjugation case >> serializeObject
+    let firstSingular = verbConjugationArticle |> getConjugation FirstSingular
+    let secondSingular = verbConjugationArticle |> getConjugation SecondSingular
+    let thirdSingular = verbConjugationArticle |> getConjugation ThirdSingular
+    let firstPlural = verbConjugationArticle |> getConjugation FirstPlural
+    let secondPlural = verbConjugationArticle |> getConjugation SecondPlural
+    let thirdPlural = verbConjugationArticle |> getConjugation ThirdPlural
 
     VerbConjugation.VerbConjugation(
         word, infinitive, pattern, 

--- a/src/Storage/Storage.fs
+++ b/src/Storage/Storage.fs
@@ -32,11 +32,6 @@ type QueryCondition =
     | Int
     | String
 
-let map func serialization defaultValue = 
-    Option.ofObj 
-    >> Option.map (func >> serialization) 
-    >> Option.defaultValue defaultValue
-    
 let serializeObject = JsonConvert.SerializeObject
 let serializeString = string
 let serializeOption<'T> : ('T option -> string) = function | Some v -> v.ToString() | None -> ""

--- a/src/WikiParsing/Articles/AdjectiveArticle.fs
+++ b/src/WikiParsing/Articles/AdjectiveArticle.fs
@@ -3,49 +3,52 @@
 open FSharp.Data
 open WikiString
 open Article
+open WikiArticles
 
 type WikiAdjective = HtmlProvider<"https://cs.wiktionary.org/wiki/nový">
 type WikiAdjectiveNový = HtmlProvider<"https://cs.wiktionary.org/wiki/nový">
 type WikiAdjectiveStarý = HtmlProvider<"https://cs.wiktionary.org/wiki/starý">
 type WikiAdjectiveVrchní = HtmlProvider<"https://cs.wiktionary.org/wiki/vrchní">
 
-let getAdjectiveProvider =
-    getUrl
-    >> WikiAdjective.Load
+let getAdjectiveProvider (AdjectiveArticle { Text = text }) =
+    text
+    |> WikiAdjective.Parse
 
-let getPluralDobrý = 
-    getUrl
-    >> WikiAdjectiveNový.Load
-    >> fun data -> data.Tables.``Skloňování[editovat]``.Rows.[0].``plurál - mužský životný``
+let getPluralDobrý (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) = 
+    text
+    |> WikiAdjectiveNový.Parse
+    |> fun data -> data.Tables.``Skloňování[editovat]``.Rows.[0].``plurál - mužský životný``
 
-let getPluralStarý = 
-    getUrl
-    >> WikiAdjectiveStarý.Load
-    >> fun data -> data.Tables.``Skloňování[editovat]2``.Rows.[0].``plurál - mužský životný``
+let getPluralStarý (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) = 
+    text
+    |> WikiAdjectiveStarý.Parse
+    |> fun data -> data.Tables.``Skloňování[editovat]2``.Rows.[0].``plurál - mužský životný``
 
-let getPluralVrchní = 
-    getUrl
-    >> WikiAdjectiveVrchní.Load
-    >> fun data -> data.Tables.``Skloňování[editovat]3``.Rows.[0].``plurál - mužský životný``
+let getPluralVrchní (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) = 
+    text
+    |> WikiAdjectiveVrchní.Parse
+    |> fun data -> data.Tables.``Skloňování[editovat]3``.Rows.[0].``plurál - mužský životný``
 
 let pluralDeclensionsMap =
     dict [ (1, getPluralDobrý)
            (2, getPluralStarý)
            (3, getPluralVrchní) ]
 
-let getNumberOfDeclensions = 
-    matches [
+let getNumberOfDeclensions (AdjectiveArticleWithPlural (AdjectiveArticle article)) = 
+    article
+    |> matches [
         Any
         Is "skloňování"
     ]
-    >> Seq.length
+    |> Seq.length
 
-let getPlural adjective = 
-    adjective
+let getPlural article =
+    article
     |> getNumberOfDeclensions
-    |> fun n -> pluralDeclensionsMap.[n] adjective
+    |> fun n -> pluralDeclensionsMap.[n] article
 
-let getComparatives =
-    getAdjectiveProvider
-    >> fun data -> data.Tables.``Stupňování[editovat]``.Rows.[1].tvar
-    >> getForms
+let getComparatives (AdjectiveArticleWithComparative article) =
+    article
+    |> getAdjectiveProvider
+    |> fun data -> data.Tables.``Stupňování[editovat]``.Rows.[1].tvar
+    |> getForms

--- a/tests/Core.IntegrationTests/AdjectiveValidationTests.fs
+++ b/tests/Core.IntegrationTests/AdjectiveValidationTests.fs
@@ -3,12 +3,18 @@
 open Xunit
 open AdjectiveValidation
 
+let getArticle =
+    Article.getArticle
+    >> Option.get
+
 [<Theory>]
 [<InlineData "nový">]
 [<InlineData "starý">]
 let ``Detects valid word for plurals`` word =
     word
-    |> isPluralValid
+    |> getArticle 
+    |> parseAdjectivePlural
+    |> Option.isSome
     |> Assert.True
 
 [<Theory>]
@@ -16,7 +22,9 @@ let ``Detects valid word for plurals`` word =
 [<InlineData "láska">]
 let ``Detects invalid word for plurals`` word =
     word
-    |> isPluralValid
+    |> getArticle 
+    |> parseAdjectivePlural
+    |> Option.isSome
     |> Assert.False
 
 [<Theory>]
@@ -24,7 +32,9 @@ let ``Detects invalid word for plurals`` word =
 [<InlineData "starý">]
 let ``Detects valid word for comparatives`` word =
     word
-    |> isComparativeValid
+    |> getArticle 
+    |> parseAdjectiveComparative
+    |> Option.isSome
     |> Assert.True
 
 [<Theory>]
@@ -32,5 +42,7 @@ let ``Detects valid word for comparatives`` word =
 [<InlineData "láska">]
 let ``Detects invalid word for comparatives`` word =
     word
-    |> isComparativeValid
+    |> getArticle 
+    |> parseAdjectiveComparative
+    |> Option.isSome
     |> Assert.False

--- a/tests/Core.IntegrationTests/FeminineNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/FeminineNounPatternDetectorTests.fs
@@ -2,12 +2,19 @@
 
 open Xunit
 open FeminineNounPatternDetector
+open WikiArticles
+
+let getArticle =
+    Article.getArticle
+    >> Option.get
+    >> NounArticle
 
 [<Theory>]
 [<InlineData "holka">]
 [<InlineData "dača">]
 let ``Detects pattern žena`` word =
     word
+    |> getArticle 
     |> isPatternŽena
     |> Assert.True
 
@@ -19,6 +26,7 @@ let ``Detects pattern žena`` word =
 [<InlineData "micve">]
 let ``Detects not pattern žena`` word =
     word
+    |> getArticle 
     |> isPatternŽena
     |> Assert.False
 
@@ -31,6 +39,7 @@ let ``Detects not pattern žena`` word =
 [<InlineData "paranoia">]
 let ``Detects pattern růže`` word =
     word
+    |> getArticle
     |> isPatternRůže
     |> Assert.True
 
@@ -41,6 +50,7 @@ let ``Detects pattern růže`` word =
 [<InlineData "noc">]
 let ``Detects not pattern růže`` word =
     word
+    |> getArticle
     |> isPatternRůže
     |> Assert.False
 
@@ -54,6 +64,7 @@ let ``Detects not pattern růže`` word =
 [<InlineData "pouť">]
 let ``Detects pattern píseň`` word =
     word
+    |> getArticle
     |> isPatternPíseň
     |> Assert.True
     
@@ -68,6 +79,7 @@ let ``Detects pattern píseň`` word =
 [<InlineData "lest">]
 let ``Detects not pattern píseň`` word =
     word
+    |> getArticle
     |> isPatternPíseň
     |> Assert.False
     
@@ -81,6 +93,7 @@ let ``Detects not pattern píseň`` word =
 [<InlineData "paměť">]
 let ``Detects pattern kost`` word =
     word
+    |> getArticle
     |> isPatternKost
     |> Assert.True
 
@@ -95,6 +108,7 @@ let ``Detects pattern kost`` word =
 [<InlineData "myš">]
 let ``Detects not pattern kost`` word =
     word
+    |> getArticle
     |> isPatternKost
     |> Assert.False
 
@@ -106,6 +120,7 @@ let ``Detects not pattern kost`` word =
 [<InlineData "noc">]
 let ``Detects no patterns`` word =
     word
+    |> getArticle
     |> getPatterns
     |> Seq.isEmpty
     |> Assert.True

--- a/tests/Core.IntegrationTests/MasculineAnimateNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/MasculineAnimateNounPatternDetectorTests.fs
@@ -2,6 +2,12 @@
 
 open Xunit
 open MasculineAnimateNounPatternDetector
+open WikiArticles
+
+let getArticle =
+    Article.getArticle
+    >> Option.get
+    >> NounArticle
 
 [<Theory>]
 [<InlineData "syn">]
@@ -11,6 +17,7 @@ open MasculineAnimateNounPatternDetector
 [<InlineData "geolog">]
 let ``Detects pattern pán`` word =
     word
+    |> getArticle
     |> isPatternPán
     |> Assert.True
 
@@ -21,6 +28,7 @@ let ``Detects pattern pán`` word =
 [<InlineData "dárce">]
 let ``Detects not pattern pán`` word =
     word
+    |> getArticle
     |> isPatternPán
     |> Assert.False
 
@@ -34,6 +42,7 @@ let ``Detects not pattern pán`` word =
 [<InlineData "Felix">]
 let ``Detects pattern muž`` word =
     word
+    |> getArticle
     |> isPatternMuž
     |> Assert.True
 
@@ -44,6 +53,7 @@ let ``Detects pattern muž`` word =
 [<InlineData "vůdce">]
 let ``Detects not pattern muž`` word =
     word
+    |> getArticle
     |> isPatternMuž
     |> Assert.False
 
@@ -56,6 +66,7 @@ let ``Detects not pattern muž`` word =
 [<InlineData "Honza">]
 let ``Detects pattern předseda`` word =
     word
+    |> getArticle
     |> isPatternPředseda
     |> Assert.True
     
@@ -65,6 +76,7 @@ let ``Detects pattern předseda`` word =
 [<InlineData "vůdce">]
 let ``Detects not pattern předseda`` word =
     word
+    |> getArticle
     |> isPatternPředseda
     |> Assert.False
     
@@ -73,6 +85,7 @@ let ``Detects not pattern předseda`` word =
 [<InlineData "dárce">]
 let ``Detects pattern soudce`` word =
     word
+    |> getArticle
     |> isPatternSoudce
     |> Assert.True
 
@@ -82,6 +95,7 @@ let ``Detects pattern soudce`` word =
 [<InlineData "kolega">]
 let ``Detects not pattern soudce`` word =
     word
+    |> getArticle
     |> isPatternSoudce
     |> Assert.False
 
@@ -91,6 +105,7 @@ let ``Detects not pattern soudce`` word =
 [<InlineData "boss">]
 let ``Detects multiple patterns`` word =
     word
+    |> getArticle
     |> getPatterns
     |> Seq.containsMultiple
     |> Assert.True
@@ -100,6 +115,7 @@ let ``Detects multiple patterns`` word =
 [<InlineData "George">]
 let ``Detects no patterns`` word =
     word
+    |> getArticle
     |> getPatterns
     |> Seq.isEmpty
     |> Assert.True

--- a/tests/Core.IntegrationTests/MasculineInanimateNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/MasculineInanimateNounPatternDetectorTests.fs
@@ -2,6 +2,12 @@
 
 open Xunit
 open MasculineInanimateNounPatternDetector
+open WikiArticles
+
+let getArticle =
+    Article.getArticle
+    >> Option.get
+    >> NounArticle
 
 [<Theory>]
 [<InlineData "strom">]
@@ -15,6 +21,7 @@ open MasculineInanimateNounPatternDetector
 [<InlineData "týl">]
 let ``Detects pattern hrad`` word =
     word
+    |> getArticle
     |> isPatternHrad
     |> Assert.True
 
@@ -25,6 +32,7 @@ let ``Detects pattern hrad`` word =
 [<InlineData "kosmos">]
 let ``Detects not pattern hrad`` word =
     word
+    |> getArticle
     |> isPatternHrad
     |> Assert.False
 
@@ -33,6 +41,7 @@ let ``Detects not pattern hrad`` word =
 [<InlineData "déšť">]
 let ``Detects pattern stroj`` word =
     word
+    |> getArticle
     |> isPatternStroj
     |> Assert.True
 
@@ -45,6 +54,7 @@ let ``Detects pattern stroj`` word =
 [<InlineData "kosmos">]
 let ``Detects not pattern stroj`` word =
     word
+    |> getArticle
     |> isPatternStroj
     |> Assert.False
 
@@ -54,6 +64,7 @@ let ``Detects not pattern stroj`` word =
 [<InlineData "kosmos">]
 let ``Detects pattern rytmus`` word =
     word
+    |> getArticle
     |> isPatternRytmus
     |> Assert.True
 
@@ -65,6 +76,7 @@ let ``Detects pattern rytmus`` word =
 [<InlineData "stroj">]
 let ``Detects not pattern rytmus`` word =
     word
+    |> getArticle
     |> isPatternRytmus
     |> Assert.False
 
@@ -75,6 +87,7 @@ let ``Detects not pattern rytmus`` word =
 [<InlineData "glóbus">]
 let ``Detects multiple patterns`` word =
     word
+    |> getArticle
     |> getPatterns
     |> Seq.containsMultiple
     |> Assert.True

--- a/tests/Core.IntegrationTests/NeuterNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/NeuterNounPatternDetectorTests.fs
@@ -2,12 +2,19 @@
 
 open Xunit
 open NeuterNounPatternDetector
+open WikiArticles
+
+let getArticle =
+    Article.getArticle
+    >> Option.get
+    >> NounArticle
 
 [<Theory>]
 [<InlineData "okno">]
 [<InlineData "slovo">]
 let ``Detects pattern město`` word =
     word
+    |> getArticle
     |> isPatternMěsto
     |> Assert.True
 
@@ -22,6 +29,7 @@ let ``Detects pattern město`` word =
 [<InlineData "muzeum">]
 let ``Detects not pattern město`` word =
     word
+    |> getArticle
     |> isPatternMěsto
     |> Assert.False
 
@@ -31,6 +39,7 @@ let ``Detects not pattern město`` word =
 [<InlineData "odpoledne">]
 let ``Detects pattern moře`` word =
     word
+    |> getArticle
     |> isPatternMoře
     |> Assert.True
 
@@ -44,6 +53,7 @@ let ``Detects pattern moře`` word =
 [<InlineData "muzeum">]
 let ``Detects not pattern moře`` word =
     word
+    |> getArticle
     |> isPatternMoře
     |> Assert.False
 
@@ -52,6 +62,7 @@ let ``Detects not pattern moře`` word =
 [<InlineData "překvapení">]
 let ``Detects pattern stavení`` word =
     word
+    |> getArticle
     |> isPatternStavení
     |> Assert.True
     
@@ -61,6 +72,7 @@ let ``Detects pattern stavení`` word =
 [<InlineData "kuře">]
 let ``Detects not pattern stavení`` word =
     word
+    |> getArticle
     |> isPatternStavení
     |> Assert.False
     
@@ -72,6 +84,7 @@ let ``Detects not pattern stavení`` word =
 [<InlineData "štíhle">]
 let ``Detects pattern kuře`` word =
     word
+    |> getArticle
     |> isPatternKuře
     |> Assert.True
 
@@ -81,6 +94,7 @@ let ``Detects pattern kuře`` word =
 [<InlineData "okno">]
 let ``Detects not pattern kuře`` word =
     word
+    |> getArticle
     |> isPatternKuře
     |> Assert.False
 
@@ -89,6 +103,7 @@ let ``Detects not pattern kuře`` word =
 [<InlineData "dilema">]
 let ``Detects pattern drama`` word =
     word
+    |> getArticle
     |> isPatternDrama
     |> Assert.True
 
@@ -100,6 +115,7 @@ let ``Detects pattern drama`` word =
 [<InlineData "pyžama">]
 let ``Detects not pattern drama`` word =
     word
+    |> getArticle
     |> isPatternDrama
     |> Assert.False
 
@@ -110,6 +126,7 @@ let ``Detects not pattern drama`` word =
 [<InlineData "vakuum">]
 let ``Detects pattern muzeum`` word =
     word
+    |> getArticle
     |> isPatternMuzeum
     |> Assert.True
 
@@ -119,6 +136,7 @@ let ``Detects pattern muzeum`` word =
 [<InlineData "centrum">]
 let ``Detects not pattern muzeum`` word =
     word
+    |> getArticle
     |> isPatternMuzeum
     |> Assert.False
 
@@ -128,6 +146,7 @@ let ``Detects not pattern muzeum`` word =
 [<InlineData "břímě">]
 let ``Detects no patterns`` word =
     word
+    |> getArticle
     |> getPatterns
     |> Seq.isEmpty
     |> Assert.True

--- a/tests/Core.IntegrationTests/NounValidationTests.fs
+++ b/tests/Core.IntegrationTests/NounValidationTests.fs
@@ -3,12 +3,18 @@
 open Xunit
 open NounValidation
 
+let getArticle = 
+    Article.getArticle
+    >> Option.get
+
 [<Theory>]
 [<InlineData "láska">]
 [<InlineData "kachna">]
 let ``Detects valid word for plurals`` word =
     word
-    |> isPluralValid
+    |> getArticle
+    |> parseNounPlural
+    |> Option.isSome
     |> Assert.True
 
 [<Theory>]
@@ -16,7 +22,9 @@ let ``Detects valid word for plurals`` word =
 [<InlineData "nový">]
 let ``Detects invalid word for plurals`` word =
     word
-    |> isPluralValid
+    |> getArticle
+    |> parseNounPlural
+    |> Option.isSome
     |> Assert.False
 
 [<Theory>]
@@ -24,7 +32,9 @@ let ``Detects invalid word for plurals`` word =
 [<InlineData "kachna">]
 let ``Detects valid word for accusatives`` word =
     word
-    |> isAccusativeValid
+    |> getArticle
+    |> parseNounAccusative
+    |> Option.isSome
     |> Assert.True
 
 [<Theory>]
@@ -32,5 +42,7 @@ let ``Detects valid word for accusatives`` word =
 [<InlineData "nový">]
 let ``Detects invalid word for accusatives`` word =
     word
-    |> isAccusativeValid
+    |> getArticle
+    |> parseNounAccusative
+    |> Option.isSome
     |> Assert.False

--- a/tests/Core.IntegrationTests/VerbValidationTests.fs
+++ b/tests/Core.IntegrationTests/VerbValidationTests.fs
@@ -3,12 +3,18 @@
 open Xunit
 open VerbValidation
 
+let getArticle = 
+    Article.getArticle
+    >> Option.get
+
 [<Theory>]
 [<InlineData "spát">]
 [<InlineData "milovat">]
 let ``Detects valid word for participles`` word =
     word
-    |> isParticipleValid
+    |> getArticle
+    |> parseVerbParticiple
+    |> Option.isSome
     |> Assert.True
 
 [<Theory>]
@@ -16,7 +22,9 @@ let ``Detects valid word for participles`` word =
 [<InlineData "nový">]
 let ``Detects invalid word for participles`` word =
     word
-    |> isParticipleValid
+    |> getArticle
+    |> parseVerbParticiple
+    |> Option.isSome
     |> Assert.False
 
 [<Theory>]
@@ -24,7 +32,9 @@ let ``Detects invalid word for participles`` word =
 [<InlineData "milovat">]
 let ``Detects valid word for imperatives`` word =
     word
-    |> isImperativeValid
+    |> getArticle
+    |> parseVerbImperative
+    |> Option.isSome
     |> Assert.True
 
 [<Theory>]
@@ -32,7 +42,9 @@ let ``Detects valid word for imperatives`` word =
 [<InlineData "nový">]
 let ``Detects invalid word for imperatives`` word =
     word
-    |> isImperativeValid
+    |> getArticle
+    |> parseVerbImperative
+    |> Option.isSome
     |> Assert.False
 
 [<Theory>]
@@ -40,7 +52,9 @@ let ``Detects invalid word for imperatives`` word =
 [<InlineData "milovat">]
 let ``Detects valid word for conjugations`` word =
     word
-    |> isConjugationValid
+    |> getArticle
+    |> parseVerbConjugation
+    |> Option.isSome
     |> Assert.True
 
 [<Theory>]
@@ -48,5 +62,7 @@ let ``Detects valid word for conjugations`` word =
 [<InlineData "nový">]
 let ``Detects invalid word for conjugations`` word =
     word
-    |> isConjugationValid
+    |> getArticle
+    |> parseVerbConjugation
+    |> Option.isSome
     |> Assert.False

--- a/tests/WikiParsing.Tests/AdjectiveArticleTests.fs
+++ b/tests/WikiParsing.Tests/AdjectiveArticleTests.fs
@@ -2,34 +2,50 @@
 
 open Xunit
 open AdjectiveArticle
+open WikiArticles
+
+let getArticle = 
+    Article.getArticle
+    >> Option.get
+    >> AdjectiveArticle
 
 [<Fact>]
 let ``Gets plural - when not nominalized``() = 
     "laskavý"
+    |> getArticle 
+    |> AdjectiveArticleWithPlural
     |> getPlural
     |> equals "laskaví"
 
 [<Fact>]
 let ``Gets plural - when nominalized once``() = 
     "vrátný"
+    |> getArticle 
+    |> AdjectiveArticleWithPlural
     |> getPlural
     |> equals "vrátní"
 
 [<Fact>]
 let ``Gets plural - when nominalized twice``() = 
     "duchovní"
+    |> getArticle 
+    |> AdjectiveArticleWithPlural
     |> getPlural
     |> equals "duchovní"
 
 [<Fact>]
 let ``Gets comparatives``() = 
     "dobrý"
+    |> getArticle 
+    |> AdjectiveArticleWithComparative
     |> getComparatives
     |> equals [| "lepší" |]
 
 [<Fact>]
 let ``Gets number of declensions``() = 
     "nový"
+    |> getArticle 
+    |> AdjectiveArticleWithPlural
     |> getNumberOfDeclensions
     |> equals 1
 

--- a/tests/WikiParsing.Tests/ArticleTests.fs
+++ b/tests/WikiParsing.Tests/ArticleTests.fs
@@ -6,23 +6,28 @@ open Article
 [<Fact>]
 let ``Detects content``() =
     "panda"
-    |> getContent
+    |> getArticle
     |> Option.isSome
     |> Assert.True
 
 [<Fact>]
 let ``Gets children parts``() =
     "ananas"
+    |> getArticle
+    |> Option.get
     |> getContent
-    |> Option.bind (getPart "čeština")
+    |> getPart "čeština"
     |> Option.map getParts
     |> Option.map (Seq.map fst >> Seq.toList)
     |> equals (Some [ "výslovnost"; "dělení"; "podstatné jméno" ])
 
 [<Fact>]
 let ``Detects no children parts``() =
-    "provozovat"
+    "ananas"
+    |> getArticle
+    |> Option.get
     |> getContent
+    |> getPart "poznámky"
     |> Option.map getParts
     |> Option.map (Seq.map fst)
     |> Option.contains Seq.empty
@@ -30,60 +35,76 @@ let ``Detects no children parts``() =
 [<Fact>]
 let ``Detects child part``() =
     "panda"
+    |> getArticle
+    |> Option.get
     |> getContent
-    |> Option.bind (getPart "čeština")
+    |> getPart "čeština"
     |> Option.isSome
     |> Assert.True
 
 [<Fact>]
 let ``Detects no child part``() =
     "panda"
+    |> getArticle
+    |> Option.get
     |> getContent
-    |> Option.bind (getPart "ruština")
+    |> getPart "ruština"
     |> Option.isSome
     |> Assert.False
 
 [<Fact>]
 let ``Detects children parts - filter``() =
     "panda"
+    |> getArticle
+    |> Option.get
     |> getContent
-    |> Option.exists (hasPartsWhen ((=) "čeština"))
+    |> hasPartsWhen ((=) "čeština")
     |> Assert.True
 
 [<Fact>]
 let ``Detects no children parts - filter``() =
     "panda"
+    |> getArticle
+    |> Option.get
     |> getContent
-    |> Option.exists (hasPartsWhen ((=) "ruština"))
+    |> hasPartsWhen ((=) "ruština")
     |> Assert.False
 
 [<Fact>]
 let ``Gets infos``() = 
     "panda"
+    |> getArticle
+    |> Option.get
     |> getContent
-    |> Option.bind (getPart "čeština")
+    |> getPart "čeština"
     |> Option.map (getInfos (Starts "rod") >> Seq.toList)
     |> equals (Some ["rod ženský"])
 
 [<Fact>]
 let ``Detects info``() = 
     "mozek"
+    |> getArticle
+    |> Option.get
     |> getContent
-    |> Option.exists (hasInfo (Is "chytrý"))
+    |> hasInfo (Is "chytrý")
     |> Assert.True
 
 [<Fact>]
 let ``Detects no info``() = 
     "panda"
+    |> getArticle
+    |> Option.get
     |> getContent
-    |> Option.exists (hasInfo (Is "evil"))
+    |> hasInfo (Is "evil")
     |> Assert.False
 
 [<Fact>]
 let ``Gets tables``() =
     "musit"
+    |> getArticle
+    |> Option.get
     |> getContent
-    |> Option.bind (getPart "čeština")
+    |> getPart "čeština"
     |> Option.bind (getPart "sloveso")
     |> Option.bind (getPart "časování")
     |> Option.map getTables
@@ -93,8 +114,10 @@ let ``Gets tables``() =
 [<Fact>]
 let ``Detects no tables``() =
     "musit"
+    |> getArticle
+    |> Option.get
     |> getContent
-    |> Option.bind (getPart "čeština")
+    |> getPart "čeština"
     |> Option.bind (getPart "sloveso")
     |> Option.bind (getPart "význam")
     |> Option.map getTables
@@ -104,30 +127,40 @@ let ``Detects no tables``() =
 [<Fact>]
 let ``Detects non-locked article``() =
     "hudba"
+    |> Article.getArticle 
+    |> Option.get
     |> isLocked
     |> Assert.False
 
 [<Fact>]
 let ``Detects locked article``() =
     "debil"
+    |> Article.getArticle 
+    |> Option.get
     |> isLocked
     |> Assert.True
 
 [<Fact>]
 let ``Gets parts of speech``() =
     "starý"
+    |> Article.getArticle 
+    |> Option.get
     |> getPartsOfSpeech
     |> seqEquals [ "podstatné jméno"; "přídavné jméno" ]
 
 [<Fact>]
 let ``Detects no parts of speech``() =
     "hello"
+    |> Article.getArticle
+    |> Option.get
     |> getPartsOfSpeech
     |> seqEquals []
 
 [<Fact>]
 let ``Gets match``() =
     "panda"
+    |> Article.getArticle
+    |> Option.get
     |> ``match`` [
         Is "podstatné jméno"
         Is "skloňování"
@@ -138,6 +171,8 @@ let ``Gets match``() =
 [<Fact>]
 let ``Gets no match``() =
     "panda"
+    |> Article.getArticle
+    |> Option.get
     |> ``match`` [
         Is "přídavné jméno"
         Is "skloňování"
@@ -147,6 +182,8 @@ let ``Gets no match``() =
 [<Fact>]
 let ``Gets matches``() =
     "bus"
+    |> Article.getArticle
+    |> Option.get
     |> matches [
         Starts "podstatné jméno"
     ]
@@ -156,6 +193,8 @@ let ``Gets matches``() =
 [<Fact>]
 let ``Gets no matches``() =
     "panda"
+    |> Article.getArticle
+    |> Option.get
     |> matches [
         Is "přídavné jméno"
         Is "skloňování"
@@ -165,6 +204,8 @@ let ``Gets no matches``() =
 [<Fact>]
 let ``Detects match``() =
     "čtvrt"
+    |> Article.getArticle
+    |> Option.get
     |> isMatch [
         Is "podstatné jméno"
         Starts "skloňování"
@@ -174,6 +215,8 @@ let ``Detects match``() =
 [<Fact>]
 let ``Detects no match``() =
     "bus"
+    |> Article.getArticle
+    |> Option.get
     |> isMatch [
         Is "přídavné jméno"
         Is "skloňování"

--- a/tests/WikiParsing.Tests/NounArticleTests.fs
+++ b/tests/WikiParsing.Tests/NounArticleTests.fs
@@ -3,58 +3,73 @@
 open Xunit
 open NounArticle
 open GrammarCategories
+open WikiArticles
+
+let getArticle =
+    Article.getArticle
+    >> Option.get
+    >> NounArticle
 
 [<Fact>]
 let ``Gets number of declensions``() =
     "starost"
+    |> getArticle
     |> getNumberOfDeclensions
     |> equals 1
 
 [<Fact>]
 let ``Gets declension wiki - indeclinable``() = 
     "dada"
+    |> getArticle
     |> getDeclensionWiki Case.Nominative Number.Plural
     |> equals ["dada"]
 
 [<Fact>]
 let ``Gets declension wiki - editable article``() = 
     "panda"
+    |> getArticle
     |> getDeclensionWiki Case.Nominative Number.Plural
     |> equals ["pandy"]
 
 [<Fact>]
 let ``Gets wiki plural wiki - locked article``() = 
     "debil"
+    |> getArticle
     |> getDeclensionWiki Case.Nominative Number.Plural
     |> equals ["debilové"]
 
 [<Fact>]
 let ``Gets declension - indeclinable``() =
     "dada"
+    |> getArticle
     |> getDeclension Case.Nominative Number.Singular
     |> seqEquals ["dada"]
 
 [<Fact>]
 let ``Gets declension - single option``() =
     "hrad"
+    |> getArticle
     |> getDeclension Case.Nominative Number.Singular
     |> seqEquals ["hrad"]
 
 [<Fact>]
 let ``Gets declension - no options``() =
     "záda"
+    |> getArticle
     |> getDeclension Case.Nominative Number.Singular
     |> seqEquals []
 
 [<Fact>]
 let ``Gets declension - multiple declensions``() =
     "čtvrt"
+    |> getArticle
     |> getDeclension Case.Nominative Number.Plural
     |> seqEquals ["čtvrtě"; "čtvrti"]
 
 [<Fact>]
 let ``Gets singulars - multiple options``() =
     "temeno"
+    |> getArticle
     |> getDeclension Case.Nominative Number.Singular
     |> seqEquals ["temeno"; "témě"]
     
@@ -63,12 +78,14 @@ let ``Gets singulars - multiple options``() =
 [<InlineData "karé">]
 let ``Detects indeclinable`` word =
     word
+    |> getArticle
     |> getDeclinability
     |> equals Indeclinable
     
 [<Fact>]
 let ``Detects declinable``() =
     "panda"
+    |> getArticle
     |> getDeclinability
     |> equals Declinable
 
@@ -78,5 +95,6 @@ let ``Detects declinable``() =
 [<InlineData "krajta">]
 let ``Gets gender`` word =
     word
+    |> getArticle
     |> getGender
     |> equals (Some "rod ženský")

--- a/tests/WikiParsing.Tests/VerbArticleTests.fs
+++ b/tests/WikiParsing.Tests/VerbArticleTests.fs
@@ -3,39 +3,54 @@
 open Xunit
 open VerbArticle
 open Conjugation
+open WikiArticles
+
+let getArticle =
+    Article.getArticle
+    >> Option.get
+    >> VerbArticle
 
 [<Fact>]
 let ``Gets imperatives - single option``() =
     "milovat"
+    |> getArticle 
+    |> VerbArticleWithImperative
     |> getImperatives
     |> equals [|"miluj"|]
 
 [<Fact>]
 let ``Gets imperatives - multiple options``() =
     "orat"
+    |> getArticle
+    |> VerbArticleWithImperative
     |> getImperatives
     |> equals [|"oř"; "orej"|]
 
 [<Fact>]
 let ``Gets participle from the second table``() = 
     "uvidět"
+    |> getArticle
+    |> VerbArticleWithParticiple
     |> getParticiples
     |> equals [|"uviděl"|]
 
 [<Fact>]
 let ``Gets participle from the third table``() = 
     "myslet"
+    |> getArticle
+    |> VerbArticleWithParticiple
     |> getParticiples
     |> equals [|"myslel"|]
 
 [<Fact>]
 let ``Gets all conjugations``() =
-    let verb =  "myslet"
+    let verb = "myslet"
+    let article = verb |> getArticle |> VerbArticleWithConjugation
     
-    getConjugation FirstSingular verb  |> equals [|"myslím"|]
-    getConjugation SecondSingular verb |> equals [|"myslíš"|]
-    getConjugation ThirdSingular verb  |> equals [|"myslí"|]
+    getConjugation FirstSingular article  |> equals [|"myslím"|]
+    getConjugation SecondSingular article |> equals [|"myslíš"|]
+    getConjugation ThirdSingular article  |> equals [|"myslí"|]
 
-    getConjugation FirstPlural verb    |> equals [|"myslíme"|]
-    getConjugation SecondPlural verb   |> equals [|"myslíte"|]
-    getConjugation ThirdPlural verb    |> equals [| "myslí"; "myslejí"|]
+    getConjugation FirstPlural article    |> equals [|"myslíme"|]
+    getConjugation SecondPlural article   |> equals [|"myslíte"|]
+    getConjugation ThirdPlural article    |> equals [| "myslí"; "myslejí"|]


### PR DESCRIPTION
The primary motivation is described in the issue. 

The most important change is the introduction of domain types for Wiki articles (module `WikiArticles`).

```fsharp
module WikiArticles

type Article = {
    Title: string
    Text: string 
}

type NounArticle = NounArticle of Article
type NounArticleWithPlural = NounArticleWithPlural of NounArticle
type NounArticleWithAccusative = NounArticleWithAccusative of NounArticle

type AdjectiveArticle = AdjectiveArticle of Article
type AdjectiveArticleWithPlural = AdjectiveArticleWithPlural of AdjectiveArticle
type AdjectiveArticleWithComparative = AdjectiveArticleWithComparative of AdjectiveArticle

type VerbArticle = VerbArticle of Article
type VerbArticleWithImperative = VerbArticleWithImperative of VerbArticle
type VerbArticleWithParticiple = VerbArticleWithParticiple of VerbArticle
type VerbArticleWithConjugation = VerbArticleWithConjugation of VerbArticle
```

Other changes basically adjust functions reading the page to work with those types instead of plain strings. Notable modification happened also in Validation modules, instead of things like `validateNounPlural` we now have things like `parseNounPlural`. 

The `Word` module in `Scraper` brings things together. And this is the module that now does single request for each word. Other modules work with acquired HTML in the form of the `Article` type.

The performance benefit actually increased expectations. I ran current version of code and new version of code 3 x 10 minutes. In average, current version processed 60 words in 10 minutes whereas new version processes 1756 words in 10 minutes. This is around 30x performance benefit.

