### PR TITLE
Reusing HttpClient within Scraper (#623)

### DIFF
--- a/src/Scraper/App.fs
+++ b/src/Scraper/App.fs
@@ -2,14 +2,16 @@
 
 open Logging
 open System.IO
+open System.Net.Http
 
 let getRandomWord() = File.ReadLines "dictionary.txt"
 
 let run log =
+    let client = new HttpClient()
     let recordWithLog word = 
         try
             log (Trace ("Processing word: " + word))
-            Word.record word
+            Word.record client word
             log (Trace ("Processed word: " + word))
         with e ->
             log (Exception (e, ("word", word)))

--- a/src/Scraper/Word.fs
+++ b/src/Scraper/Word.fs
@@ -33,11 +33,10 @@ let getTasks article =
     |> getPartsOfSpeech 
     |> Seq.collect (recordCzechPartOfSpeech article)
 
-let record word =
-    word
-    |> getArticle
-    |> Option.map getTasks
-    |> Option.defaultValue Seq.empty
-    |> Async.Parallel
-    |> Async.Ignore
-    |> Async.RunSynchronously
+let record client =
+    getArticle client
+    >> Option.map getTasks
+    >> Option.defaultValue Seq.empty
+    >> Async.Parallel
+    >> Async.Ignore
+    >> Async.RunSynchronously

--- a/src/WikiParsing/Articles/Article.fs
+++ b/src/WikiParsing/Articles/Article.fs
@@ -38,8 +38,7 @@ let getResponse (client: HttpClient) (url: string) =
 
 let getUrl = (+) wikiUrl
 
-let getArticle entry = 
-    let client = new HttpClient()
+let getArticle client entry = 
     let url = entry |> getUrl
     let response = url |> getResponse client
     if response.IsSuccessStatusCode

--- a/tests/Core.IntegrationTests/AdjectiveValidationTests.fs
+++ b/tests/Core.IntegrationTests/AdjectiveValidationTests.fs
@@ -3,10 +3,6 @@
 open Xunit
 open AdjectiveValidation
 
-let getArticle =
-    Article.getArticle
-    >> Option.get
-
 [<Theory>]
 [<InlineData "nový">]
 [<InlineData "starý">]

--- a/tests/Core.IntegrationTests/FeminineNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/FeminineNounPatternDetectorTests.fs
@@ -5,8 +5,7 @@ open FeminineNounPatternDetector
 open WikiArticles
 
 let getArticle =
-    Article.getArticle
-    >> Option.get
+    getArticle
     >> NounArticle
 
 [<Theory>]

--- a/tests/Core.IntegrationTests/Helper.fs
+++ b/tests/Core.IntegrationTests/Helper.fs
@@ -1,6 +1,12 @@
 ﻿[<AutoOpen>]
 module Helper
 
+open System.Net.Http
 open Xunit
 
 let equals (expected: 'T) (actual: 'T) = Assert.Equal<'T>(expected, actual)
+
+let private Client = new HttpClient()
+let getArticle = 
+    Article.getArticle Client
+    >> Option.get

--- a/tests/Core.IntegrationTests/MasculineAnimateNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/MasculineAnimateNounPatternDetectorTests.fs
@@ -5,8 +5,7 @@ open MasculineAnimateNounPatternDetector
 open WikiArticles
 
 let getArticle =
-    Article.getArticle
-    >> Option.get
+    getArticle
     >> NounArticle
 
 [<Theory>]

--- a/tests/Core.IntegrationTests/MasculineInanimateNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/MasculineInanimateNounPatternDetectorTests.fs
@@ -5,8 +5,7 @@ open MasculineInanimateNounPatternDetector
 open WikiArticles
 
 let getArticle =
-    Article.getArticle
-    >> Option.get
+    getArticle
     >> NounArticle
 
 [<Theory>]

--- a/tests/Core.IntegrationTests/NeuterNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/NeuterNounPatternDetectorTests.fs
@@ -5,8 +5,7 @@ open NeuterNounPatternDetector
 open WikiArticles
 
 let getArticle =
-    Article.getArticle
-    >> Option.get
+    getArticle
     >> NounArticle
 
 [<Theory>]

--- a/tests/Core.IntegrationTests/NounValidationTests.fs
+++ b/tests/Core.IntegrationTests/NounValidationTests.fs
@@ -3,10 +3,6 @@
 open Xunit
 open NounValidation
 
-let getArticle = 
-    Article.getArticle
-    >> Option.get
-
 [<Theory>]
 [<InlineData "láska">]
 [<InlineData "kachna">]

--- a/tests/Core.IntegrationTests/VerbValidationTests.fs
+++ b/tests/Core.IntegrationTests/VerbValidationTests.fs
@@ -3,10 +3,6 @@
 open Xunit
 open VerbValidation
 
-let getArticle = 
-    Article.getArticle
-    >> Option.get
-
 [<Theory>]
 [<InlineData "spát">]
 [<InlineData "milovat">]

--- a/tests/WikiParsing.Tests/AdjectiveArticleTests.fs
+++ b/tests/WikiParsing.Tests/AdjectiveArticleTests.fs
@@ -5,8 +5,7 @@ open AdjectiveArticle
 open WikiArticles
 
 let getArticle = 
-    Article.getArticle
-    >> Option.get
+    getArticle
     >> AdjectiveArticle
 
 [<Fact>]

--- a/tests/WikiParsing.Tests/ArticleTests.fs
+++ b/tests/WikiParsing.Tests/ArticleTests.fs
@@ -6,15 +6,12 @@ open Article
 [<Fact>]
 let ``Detects content``() =
     "panda"
-    |> getArticle
-    |> Option.isSome
-    |> Assert.True
+    |> Helper.getArticle
 
 [<Fact>]
 let ``Gets children parts``() =
     "ananas"
-    |> getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> getContent
     |> getPart "čeština"
     |> Option.map getParts
@@ -24,8 +21,7 @@ let ``Gets children parts``() =
 [<Fact>]
 let ``Detects no children parts``() =
     "ananas"
-    |> getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> getContent
     |> getPart "poznámky"
     |> Option.map getParts
@@ -35,8 +31,7 @@ let ``Detects no children parts``() =
 [<Fact>]
 let ``Detects child part``() =
     "panda"
-    |> getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> getContent
     |> getPart "čeština"
     |> Option.isSome
@@ -45,8 +40,7 @@ let ``Detects child part``() =
 [<Fact>]
 let ``Detects no child part``() =
     "panda"
-    |> getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> getContent
     |> getPart "ruština"
     |> Option.isSome
@@ -55,8 +49,7 @@ let ``Detects no child part``() =
 [<Fact>]
 let ``Detects children parts - filter``() =
     "panda"
-    |> getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> getContent
     |> hasPartsWhen ((=) "čeština")
     |> Assert.True
@@ -64,8 +57,7 @@ let ``Detects children parts - filter``() =
 [<Fact>]
 let ``Detects no children parts - filter``() =
     "panda"
-    |> getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> getContent
     |> hasPartsWhen ((=) "ruština")
     |> Assert.False
@@ -73,8 +65,7 @@ let ``Detects no children parts - filter``() =
 [<Fact>]
 let ``Gets infos``() = 
     "panda"
-    |> getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> getContent
     |> getPart "čeština"
     |> Option.map (getInfos (Starts "rod") >> Seq.toList)
@@ -83,8 +74,7 @@ let ``Gets infos``() =
 [<Fact>]
 let ``Detects info``() = 
     "mozek"
-    |> getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> getContent
     |> hasInfo (Is "chytrý")
     |> Assert.True
@@ -92,8 +82,7 @@ let ``Detects info``() =
 [<Fact>]
 let ``Detects no info``() = 
     "panda"
-    |> getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> getContent
     |> hasInfo (Is "evil")
     |> Assert.False
@@ -101,8 +90,7 @@ let ``Detects no info``() =
 [<Fact>]
 let ``Gets tables``() =
     "musit"
-    |> getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> getContent
     |> getPart "čeština"
     |> Option.bind (getPart "sloveso")
@@ -114,8 +102,7 @@ let ``Gets tables``() =
 [<Fact>]
 let ``Detects no tables``() =
     "musit"
-    |> getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> getContent
     |> getPart "čeština"
     |> Option.bind (getPart "sloveso")
@@ -127,40 +114,35 @@ let ``Detects no tables``() =
 [<Fact>]
 let ``Detects non-locked article``() =
     "hudba"
-    |> Article.getArticle 
-    |> Option.get
+    |> Helper.getArticle 
     |> isLocked
     |> Assert.False
 
 [<Fact>]
 let ``Detects locked article``() =
     "debil"
-    |> Article.getArticle 
-    |> Option.get
+    |> Helper.getArticle 
     |> isLocked
     |> Assert.True
 
 [<Fact>]
 let ``Gets parts of speech``() =
     "starý"
-    |> Article.getArticle 
-    |> Option.get
+    |> Helper.getArticle 
     |> getPartsOfSpeech
     |> seqEquals [ "podstatné jméno"; "přídavné jméno" ]
 
 [<Fact>]
 let ``Detects no parts of speech``() =
     "hello"
-    |> Article.getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> getPartsOfSpeech
     |> seqEquals []
 
 [<Fact>]
 let ``Gets match``() =
     "panda"
-    |> Article.getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> ``match`` [
         Is "podstatné jméno"
         Is "skloňování"
@@ -171,8 +153,7 @@ let ``Gets match``() =
 [<Fact>]
 let ``Gets no match``() =
     "panda"
-    |> Article.getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> ``match`` [
         Is "přídavné jméno"
         Is "skloňování"
@@ -182,8 +163,7 @@ let ``Gets no match``() =
 [<Fact>]
 let ``Gets matches``() =
     "bus"
-    |> Article.getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> matches [
         Starts "podstatné jméno"
     ]
@@ -193,8 +173,7 @@ let ``Gets matches``() =
 [<Fact>]
 let ``Gets no matches``() =
     "panda"
-    |> Article.getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> matches [
         Is "přídavné jméno"
         Is "skloňování"
@@ -204,8 +183,7 @@ let ``Gets no matches``() =
 [<Fact>]
 let ``Detects match``() =
     "čtvrt"
-    |> Article.getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> isMatch [
         Is "podstatné jméno"
         Starts "skloňování"
@@ -215,8 +193,7 @@ let ``Detects match``() =
 [<Fact>]
 let ``Detects no match``() =
     "bus"
-    |> Article.getArticle
-    |> Option.get
+    |> Helper.getArticle
     |> isMatch [
         Is "přídavné jméno"
         Is "skloňování"

--- a/tests/WikiParsing.Tests/Helper.fs
+++ b/tests/WikiParsing.Tests/Helper.fs
@@ -1,7 +1,13 @@
 ﻿[<AutoOpen>]
 module Helper
 
+open System.Net.Http
 open Xunit
 
 let equals (expected: 'T) (actual: 'T) = Assert.Equal<'T>(expected, actual)
 let seqEquals (expected: 'T list) (actual: seq<'T>) = Assert.Equal<'T>(expected, Seq.toList actual)
+
+let private Client = new HttpClient()
+let getArticle = 
+    Article.getArticle Client
+    >> Option.get

--- a/tests/WikiParsing.Tests/NounArticleTests.fs
+++ b/tests/WikiParsing.Tests/NounArticleTests.fs
@@ -6,8 +6,7 @@ open GrammarCategories
 open WikiArticles
 
 let getArticle =
-    Article.getArticle
-    >> Option.get
+    getArticle
     >> NounArticle
 
 [<Fact>]

--- a/tests/WikiParsing.Tests/VerbArticleTests.fs
+++ b/tests/WikiParsing.Tests/VerbArticleTests.fs
@@ -6,8 +6,7 @@ open Conjugation
 open WikiArticles
 
 let getArticle =
-    Article.getArticle
-    >> Option.get
+    getArticle
     >> VerbArticle
 
 [<Fact>]


### PR DESCRIPTION
So back in a day there was a [discussion](https://github.com/psfinaki/CheckYourCzech/pull/622#pullrequestreview-348370725) to reuse `HttpClient` for Scraper but back then it was hard to do because of multiple places where the app communicated with the internet.

After recent optimizations, for every word the app accesses Wiki only once. So it is much easier to inject single `HttpClient` for all the calls. The actual change is the first three files, everything else is adjustments in tests.

As per my amateur benchmarks, this change actually makes quite a difference - in average the app  processes 3.7x more words and tests run 20% faster.