### PR TITLE
Improved WikiString framework (#646)

### DIFF
--- a/src/Common/StringHelper.fs
+++ b/src/Common/StringHelper.fs
@@ -29,7 +29,7 @@ let containsAny (values: seq<string>) (s: string) =
     let containsOne = s.Contains
     values |> Seq.exists containsOne
 
-let contains (s: string) = containsAny (seq { s })
+let contains (s: string) = containsAny (seq { yield s })
 
 let takeLast n (s: string) = s.Substring (s.Length - n)
 

--- a/src/Common/StringHelper.fs
+++ b/src/Common/StringHelper.fs
@@ -29,4 +29,10 @@ let containsAny (values: seq<string>) (s: string) =
     let containsOne = s.Contains
     values |> Seq.exists containsOne
 
+let contains (s: string) = containsAny (seq { s })
+
 let takeLast n (s: string) = s.Substring (s.Length - n)
+
+let isMatch pattern string = Regex.IsMatch(string, pattern)
+
+let ``match`` pattern string = Regex.Match(string, pattern)

--- a/src/WikiParsing/WikiString.fs
+++ b/src/WikiParsing/WikiString.fs
@@ -2,44 +2,91 @@
 
 open StringHelper
 
-let formSeparators = [|'/'; ','|]
+type private Form = {
+    Label: string option
+    Word: string
+}
 
-let allowedLabels  = [
-    "(řidč.)"
-    "(zřídka)"
-    "(knižně)"
+let private formSeparators = [|'/'; ','|]
+let private referencePattern = "\[(p )?\d*\]"
+let private allowedLabels  = [
+     "řidč."
+     "zřídka"
+     "knižně"
     ]
 
-let rejectedLabels = [
-    "(zastarale)"
-    "(hovorově)"
-    "(v obecném jazyce)"
-    "(archaicky)"
-    "(básnicky)"
-    "(nářečně)"
-    "*"
-    ]
+let private isBlank s = s = "" || s = "—" || s = "-"
+let private meansUnused = ends "*"
+let private isPlainWord = isMatch "^\w+[\s\-]?\w+$"
+let private isSpaced s = s |> starts " " || s |> ends " " 
+let private hasReferences = contains "["
+let private hasLabel = starts "("
+let private hasSecondFormAfterColon = contains ":"
+let private hasSplitForms = containsAny (formSeparators |> Seq.map string)
 
-let referencePattern = "\[(p )?\d*\]"
+let private getLabeledForm =
+    ``match`` "^\((?<label>.*)\) (?<word>\w*)$"
+    >> fun m ->
+    { 
+        Word = m.Groups.["word"].Value
+        Label = Some m.Groups.["label"].Value
+    }
 
-let isBlank s = 
-    s = "" ||
-    s = "—" || 
-    s = "-"
+let private getFormsWhenColon =
+    ``match`` "^(?<word1>\w*) \((?<label>\w*): (?<word2>\w*)\)$"
+    >> fun m -> [|
+    { 
+      Word = m.Groups.["word1"].Value
+      Label = None
+    }
+    {   
+      Word = m.Groups.["word2"].Value
+      Label = Some m.Groups.["label"].Value
+    } |]
 
-let isWord = not << isBlank
-let isOfficial = not << containsAny rejectedLabels
+let rec private getFormsInner = function
+    | string when string |> isBlank ->
+        [||]
 
-let removeLabels = removeMany allowedLabels >> trim
-let removeReferences = removePattern referencePattern >> trim
+    | string when string |> meansUnused ->
+        [||]
+
+    | string when string |> isPlainWord ->
+        [|{ Word = string; Label = None }|]
+
+    | string when string |> isSpaced ->
+        string
+        |> trim
+        |> getFormsInner
+
+    | string when string |> hasReferences ->
+        string
+        |> removePattern referencePattern
+        |> getFormsInner
+
+    | string when string |> hasLabel ->
+        [| getLabeledForm string |]
+
+    | string when string |> hasSecondFormAfterColon ->
+        getFormsWhenColon string
+
+    | string when string |> hasSplitForms ->
+        string 
+        |> split formSeparators
+        |> Array.collect getFormsInner
+
+    | string ->
+        invalidOp ("odd string: " + string)
+
+let private isFormAppropriate form = 
+    match form.Label with
+    | None -> true
+    | Some label -> allowedLabels |> Seq.contains label
 
 let getForms =
-    split formSeparators
-    >> Array.map trim
-    >> Array.filter isWord
-    >> Array.filter isOfficial
-    >> Array.map removeLabels
-    >> Array.map removeReferences
+    getFormsInner
+    >> Array.filter isFormAppropriate
+    >> Array.map (fun form -> form.Word)
 
 let getForm =
     getForms

--- a/tests/WikiParsing.Tests/WikiParsing.Tests.fsproj
+++ b/tests/WikiParsing.Tests/WikiParsing.Tests.fsproj
@@ -12,8 +12,8 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="WikiStringTests.fs" />
     <Compile Include="Helper.fs" />
+    <Compile Include="WikiStringTests.fs" />
     <Compile Include="ArticleTests.fs" />
     <Compile Include="NounArticleTests.fs" />
     <Compile Include="AdjectiveArticleTests.fs" />


### PR DESCRIPTION
The original motivation was to handle forms like `abdikuji (hovorově: abdikuju)` (see the [task](https://github.com/psfinaki/CheckYourCzech/issues/646)). 

However adjusting existing logic there was significantly decreasing clarity of what was going on. So I decided to rewrite the framework via regex and recursion. The code also has small domain type `Form`.

Most of the code in the framework is private now and that allowed tests to be more representative, having real Wiki forms there as inputs and what we expect from them as outputs.

I have run Scraper with this logic for a couple of hours, parsed forms look alright.