### PR TITLE
More robust exercise models (#652)

### DIFF
--- a/src/Common/Common.fsproj
+++ b/src/Common/Common.fsproj
@@ -19,5 +19,6 @@
     <Compile Include="Utils.fs" />
     <Compile Include="StringHelper.fs" />
     <Compile Include="GenderTranslations.fs" />
+    <Compile Include="Exercises.fs" />
   </ItemGroup>
 </Project>

--- a/src/Common/Conjugation.fs
+++ b/src/Common/Conjugation.fs
@@ -15,3 +15,12 @@ let pronounToString = function
     | FirstPlural     -> "my"
     | SecondPlural    -> "vy"
     | ThirdPlural     -> "oni"
+
+type Conjugation = {
+    FirstSingular: seq<string>
+    SecondSingular: seq<string>
+    ThirdSingular: seq<string>
+    FirstPlural: seq<string>
+    SecondPlural: seq<string>
+    ThirdPlural: seq<string>
+}

--- a/src/Common/Exercises.fs
+++ b/src/Common/Exercises.fs
@@ -1,0 +1,55 @@
+﻿module Exercises
+
+open GrammarCategories
+
+type NounPlural = {
+    Id: string
+    Singular: string
+    Plurals: seq<string>
+    Gender: Gender option
+    Patterns: seq<string>
+}
+
+type NounAccusative = {
+    Id: string
+    Nominative: string
+    Accusatives: seq<string>
+    Gender: Gender option
+    Patterns: seq<string>
+}
+
+type AdjectivePlural = {
+    Id: string
+    Singular: string
+    Plural: string
+}
+
+type AdjectiveComparative = {
+    Id: string
+    Positive: string
+    Comparatives: seq<string>
+    IsRegular: bool
+}
+
+type VerbImperative = {
+    Id: string
+    Indicative: string
+    Imperatives: seq<string>
+    Class: Verbs.VerbClass option
+    Pattern: string option
+}
+
+type VerbParticiple = {
+    Id: string
+    Infinitive: string
+    Participles: seq<string>
+    Pattern: Verbs.Pattern
+    IsRegular: bool
+}
+
+type VerbConjugation = {
+    Id: string
+    Infinitive: string
+    Pattern: Verbs.Pattern
+    Conjugation: Conjugation.Conjugation
+}

--- a/src/Scraper/WordRegistration/AdjectiveRegistration.fs
+++ b/src/Scraper/WordRegistration/AdjectiveRegistration.fs
@@ -3,24 +3,25 @@
 open Storage
 open Adjective
 open WikiArticles
+open Exercises
 
 let registerAdjectivePlural adjectiveArticleWithPlural =
     let (AdjectiveArticleWithPlural adjectiveArticle) = adjectiveArticleWithPlural
     let (AdjectiveArticle { Title = word }) = adjectiveArticle
 
-    let singular = word |> serializeObject
-    let plural = adjectiveArticleWithPlural |> getPlural |> serializeObject
-
-    AdjectivePlural.AdjectivePlural(word, singular, plural)
-    |> upsert "adjectiveplurals"
+    upsert "adjectiveplurals" (AdjectivePlural.AdjectivePlural {
+        Id = word
+        Singular = word
+        Plural = adjectiveArticleWithPlural |> getPlural
+    })
 
 let registerAdjectiveComparative adjectiveArticleWithComparative =
     let (AdjectiveArticleWithComparative adjectiveArticle) = adjectiveArticleWithComparative
     let (AdjectiveArticle { Title = word }) = adjectiveArticle
 
-    let positive = word |> serializeObject
-    let comparatives = adjectiveArticleWithComparative |> getComparatives |> serializeObject
-    let isRegular = adjectiveArticleWithComparative |> hasRegularComparative
-
-    AdjectiveComparative.AdjectiveComparative(word, positive, comparatives, isRegular)
-    |> upsert "adjectivecomparatives"
+    upsert "adjectivecomparatives" (AdjectiveComparative.AdjectiveComparative {
+        Id = word
+        Positive = word
+        Comparatives = adjectiveArticleWithComparative |> getComparatives
+        IsRegular = adjectiveArticleWithComparative |> hasRegularComparative
+    })

--- a/src/Scraper/WordRegistration/NounRegistration.fs
+++ b/src/Scraper/WordRegistration/NounRegistration.fs
@@ -4,27 +4,28 @@ open Storage
 open Noun
 open GrammarCategories
 open WikiArticles
+open Exercises
 
 let registerNounPlural nounArticleWithPlural =
     let (NounArticleWithPlural nounArticle) = nounArticleWithPlural
     let (NounArticle { Title = word }) = nounArticle
 
-    let singular = word |> serializeObject
-    let plurals = nounArticle |> getDeclension Case.Nominative Number.Plural |> serializeObject
-    let gender = nounArticle |> getGender |> serializeOption<Gender>
-    let patterns = nounArticle |> getPatterns |> serializeObject
-
-    NounPlural.NounPlural(word, singular, plurals, gender, patterns)
-    |> upsert "nounplurals"
+    upsert "nounplurals" (NounPlural.NounPlural {
+        Id = word
+        Singular = word
+        Plurals = nounArticle |> getDeclension Case.Nominative Number.Plural
+        Gender = nounArticle |> getGender
+        Patterns = nounArticle |> getPatterns
+    })
 
 let registerNounAccusative nounArticleWithAccusative =
     let (NounArticleWithAccusative nounArticle) = nounArticleWithAccusative
     let (NounArticle { Title = word }) = nounArticle
 
-    let nominative = word |> serializeObject
-    let accusatives = nounArticle |> getDeclension Case.Accusative Number.Singular |> serializeObject
-    let gender = nounArticle |> getGender |> serializeOption<Gender>
-    let patterns = nounArticle |> getPatterns |> serializeObject
-
-    NounAccusative.NounAccusative(word, nominative, accusatives, gender, patterns)
-    |> upsert "nounaccusatives"
+    upsert "nounaccusatives" (NounAccusative.NounAccusative {   
+        Id = word
+        Nominative = word
+        Accusatives = nounArticle |> getDeclension Case.Accusative Number.Singular
+        Gender = nounArticle |> getGender
+        Patterns = nounArticle |> getPatterns 
+    })

--- a/src/Scraper/WordRegistration/VerbRegistration.fs
+++ b/src/Scraper/WordRegistration/VerbRegistration.fs
@@ -2,52 +2,48 @@
 
 open Storage
 open Verb
-open Verbs
 open Conjugation
 open WikiArticles
+open Exercises
 
 let registerVerbImperative verbArticleWithImperative =
     let (VerbArticleWithImperative verbArticle) = verbArticleWithImperative
     let (VerbArticle { Title = word }) = verbArticle
 
-    let indicative = word |> serializeObject
-    let imperatives = verbArticleWithImperative |> getImperatives |> serializeObject
-    let ``class`` = verbArticle |> getClass |> serializeOption<VerbClass>
-    let pattern = verbArticle |> getImperativePattern |> serializeOption<string>
-
-    VerbImperative.VerbImperative(word, indicative, imperatives, ``class``, pattern)
-    |> upsert "verbimperatives"
+    upsert "verbimperatives" (VerbImperative.VerbImperative {
+        Id = word
+        Indicative = word
+        Imperatives = verbArticleWithImperative |> getImperatives
+        Class = verbArticle |> getClass
+        Pattern = verbArticle |> getImperativePattern
+    })
 
 let registerVerbParticiple verbArticleWithParticiple = 
     let (VerbArticleWithParticiple verbArticle) = verbArticleWithParticiple
     let (VerbArticle { Title = word }) = verbArticle
 
-    let wordId = word
-    let infinitive = word |> serializeObject
-    let participles = verbArticleWithParticiple |> getParticiples |> serializeObject
-    let pattern = verbArticle |> getParticiplePattern |> serializeString
-    let isRegular = verbArticleWithParticiple |> hasRegularParticiple
-
-    VerbParticiple.VerbParticiple(word, infinitive, participles, pattern, isRegular)
-    |> upsert "verbparticiples"
+    upsert "verbparticiples" (VerbParticiple.VerbParticiple {
+        Id = word
+        Infinitive = word
+        Participles = verbArticleWithParticiple |> getParticiples
+        Pattern = verbArticle |> getParticiplePattern
+        IsRegular =  verbArticleWithParticiple |> hasRegularParticiple
+    })
 
 let registerVerbConjugation verbConjugationArticle =
     let (VerbArticleWithConjugation verbArticle) = verbConjugationArticle
     let (VerbArticle { Title = word }) = verbArticle
 
-    let infinitive = word |> serializeObject
-    let pattern = verbArticle |> getParticiplePattern |> serializeString
-
-    let getConjugation case = getConjugation case >> serializeObject
-    let firstSingular = verbConjugationArticle |> getConjugation FirstSingular
-    let secondSingular = verbConjugationArticle |> getConjugation SecondSingular
-    let thirdSingular = verbConjugationArticle |> getConjugation ThirdSingular
-    let firstPlural = verbConjugationArticle |> getConjugation FirstPlural
-    let secondPlural = verbConjugationArticle |> getConjugation SecondPlural
-    let thirdPlural = verbConjugationArticle |> getConjugation ThirdPlural
-
-    VerbConjugation.VerbConjugation(
-        word, infinitive, pattern, 
-        firstSingular, secondSingular, thirdSingular, 
-        firstPlural, secondPlural, thirdPlural)
-    |> upsert "verbconjugation"
+    upsert "verbconjugation" (VerbConjugation.VerbConjugation {
+        Id = word
+        Infinitive = word
+        Pattern =  verbArticle |> getParticiplePattern
+        Conjugation = {
+            FirstSingular = verbConjugationArticle |> getConjugation FirstSingular
+            SecondSingular = verbConjugationArticle |> getConjugation SecondSingular
+            ThirdSingular = verbConjugationArticle |> getConjugation ThirdSingular
+            FirstPlural = verbConjugationArticle |> getConjugation FirstPlural
+            SecondPlural = verbConjugationArticle |> getConjugation SecondPlural
+            ThirdPlural = verbConjugationArticle |> getConjugation ThirdPlural
+        }
+    })

--- a/src/Server/Tasks/Adjective.fs
+++ b/src/Server/Tasks/Adjective.fs
@@ -11,8 +11,8 @@ let getAdjectivePluralsTask next (ctx : HttpContext) =
         let! adjective = tryGetRandom<AdjectivePlural.AdjectivePlural> "adjectiveplurals" []
     
         let getTask (adjective: AdjectivePlural.AdjectivePlural) = 
-            let singular = getAs<string> adjective.Singular
-            let plural = getAs<string> adjective.Plural
+            let singular = adjective.Singular
+            let plural = adjective.Plural
             Task(singular, [| plural |])
 
         let task = adjective |> Option.map getTask |> Option.toObj 
@@ -28,8 +28,8 @@ let getAdjectiveComparativesTask next (ctx : HttpContext) =
         let! adjective = tryGetRandom<AdjectiveComparative.AdjectiveComparative> "adjectivecomparatives" filters
     
         let getTask (adjective: AdjectiveComparative.AdjectiveComparative) = 
-            let positive = getAs<string> adjective.Positive
-            let comparatives = getAs<string []> adjective.Comparatives
+            let positive = adjective.Positive
+            let comparatives = adjective.Comparatives
             Task(positive, comparatives)
     
         let task = adjective |> Option.map getTask |> Option.toObj 

--- a/src/Server/Tasks/Noun.fs
+++ b/src/Server/Tasks/Noun.fs
@@ -12,7 +12,7 @@ let getNounPluralsTask next (ctx: HttpContext) =
         let genderFilter = getAzureFilter "Gender" String genderFromQuery
 
         let patternFromQuery = ctx.GetQueryStringValue "pattern"
-        let patternFilterCondition (pattern: string) (noun: NounPlural.NounPlural) = noun.Patterns.Contains(pattern)
+        let patternFilterCondition (pattern: string) (noun: NounPlural.NounPlural) = noun.Patterns |> Seq.contains pattern
         let patternFilter = getPostFilter patternFilterCondition patternFromQuery
 
         let azureFilters = [ genderFilter ] |> Seq.choose id
@@ -20,8 +20,8 @@ let getNounPluralsTask next (ctx: HttpContext) =
         
         let! noun = tryGetRandomWithFilters<NounPlural.NounPlural> "nounplurals" azureFilters postFilters
         let getTask (noun: NounPlural.NounPlural) = 
-            let singular = getAs<string> noun.Singular
-            let plurals = getAs<string []> noun.Plurals
+            let singular = noun.Singular
+            let plurals = noun.Plurals
             Task(singular, plurals)
         
         let task = noun |> Option.map getTask |> Option.toObj
@@ -34,7 +34,7 @@ let getNounAccusativesTask next (ctx : HttpContext) =
         let genderFilter = getAzureFilter "Gender" String genderFromQuery
 
         let patternFromQuery = ctx.GetQueryStringValue "pattern"
-        let patternFilterCondition (pattern: string) (noun: NounAccusative.NounAccusative) = noun.Patterns.Contains(pattern)
+        let patternFilterCondition (pattern: string) (noun: NounAccusative.NounAccusative) = noun.Patterns |> Seq.contains pattern
         let patternFilter = getPostFilter patternFilterCondition patternFromQuery
 
         let azureFilters = [ genderFilter ] |> Seq.choose id
@@ -42,8 +42,8 @@ let getNounAccusativesTask next (ctx : HttpContext) =
 
         let! noun = tryGetRandomWithFilters<NounAccusative.NounAccusative> "nounaccusatives" azureFilters postFilters
         let getTask (noun: NounAccusative.NounAccusative) = 
-            let singular = getAs<string> noun.Nominative 
-            let accusatives = getAs<string []> noun.Accusatives
+            let singular = noun.Nominative 
+            let accusatives = noun.Accusatives
             Task(singular, accusatives)
 
         let task = noun |> Option.map getTask |> Option.toObj

--- a/src/Server/Tasks/Utils.fs
+++ b/src/Server/Tasks/Utils.fs
@@ -12,4 +12,4 @@ let getPostFilter filterCondition = function
 [<AllowNullLiteral>]
 type Task(word, answers) = 
     member this.Word: string = word
-    member this.Answers: string [] = answers
+    member this.Answers: seq<string> = answers

--- a/src/Server/Tasks/Verb.fs
+++ b/src/Server/Tasks/Verb.fs
@@ -23,8 +23,8 @@ let getVerbImperativesTask next (ctx : HttpContext) =
         let! verb = tryGetRandom<VerbImperative.VerbImperative> "verbimperatives" filters
 
         let getTask (verb: VerbImperative.VerbImperative) = 
-            let indicative = getAs<string> verb.Indicative
-            let imperatives = getAs<string []> verb.Imperatives
+            let indicative = verb.Indicative
+            let imperatives = verb.Imperatives
             Task(indicative, imperatives)
 
         let task = verb |> Option.map getTask |> Option.toObj 
@@ -46,8 +46,8 @@ let getVerbParticiplesTask next (ctx: HttpContext) =
         let! verb = tryGetRandom<VerbParticiple.VerbParticiple> "verbparticiples" filters
 
         let getTask (verb: VerbParticiple.VerbParticiple) = 
-            let infinitive = getAs<string> verb.Infinitive
-            let participles = getAs<string []> verb.Participles
+            let infinitive = verb.Infinitive
+            let participles = verb.Participles
             Task(infinitive, participles)
 
         let task = verb |> Option.map getTask |> Option.toObj 
@@ -74,8 +74,8 @@ let getVerbConjugationTask next (ctx: HttpContext) =
         let! verb = tryGetRandom<VerbConjugation.VerbConjugation> "verbconjugation" filters
         let getTask (verb: VerbConjugation.VerbConjugation) =
             let pronoun = getRandomUnion<Pronoun>
-            let infinitive = getAs<string> verb.Infinitive
-            let answers = getAs<string[]> (getConjugation verb pronoun)
+            let infinitive = verb.Infinitive
+            let answers = getConjugation verb pronoun
             let pn = pronounToString pronoun
             let word = sprintf "(%s) %s _____" infinitive pn 
             Task(word, answers)

--- a/src/Storage/Defaults.fs
+++ b/src/Storage/Defaults.fs
@@ -1,0 +1,69 @@
+﻿module Defaults
+
+open Exercises
+
+type NounPlural with 
+    static member Default = {
+        Id = null
+        Singular = null
+        Plurals = null
+        Gender = None
+        Patterns = null
+    }
+
+type NounAccusative with 
+    static member Default = {
+        Id = null
+        Nominative = null
+        Accusatives = null
+        Gender = None
+        Patterns = null
+    }
+
+type AdjectivePlural with 
+    static member Default = {
+        Id = null
+        Singular = null
+        Plural = null
+    }
+
+type AdjectiveComparative with 
+    static member Default = {
+        Id = null
+        Positive = null
+        Comparatives = null
+        IsRegular = false
+    }
+
+type VerbImperative with 
+    static member Default = {
+        Id = null
+        Indicative = null
+        Imperatives = null
+        Class = None
+        Pattern = None
+    }
+
+type VerbParticiple with 
+    static member Default = {
+        Id = null
+        Infinitive = null
+        Participles = null
+        Pattern = Verbs.Pattern.Common
+        IsRegular = false
+    }
+
+type VerbConjugation with 
+    static member Default = {
+        Id = null
+        Infinitive = null
+        Pattern = Verbs.Pattern.Common
+        Conjugation = {
+            FirstSingular = null
+            SecondSingular = null
+            ThirdSingular = null
+            FirstPlural = null
+            SecondPlural = null
+            ThirdPlural = null
+        }
+    }

--- a/src/Storage/ExerciseModels/AdjectiveComparative.fs
+++ b/src/Storage/ExerciseModels/AdjectiveComparative.fs
@@ -1,16 +1,15 @@
 ﻿module AdjectiveComparative
 
-open Microsoft.WindowsAzure.Storage.Table
+open Exercises
+open Storage
+open Defaults
 
-type AdjectiveComparative(word: string,
-                          positive: string,
-                          comparatives: string,
-                          isRegular: bool) =
+type AdjectiveComparative(model: Exercises.AdjectiveComparative) =
 
-    inherit TableEntity(word, word)
+    inherit BaseEntity.BaseEntity(model.Id)
     
-    new() = AdjectiveComparative(null, null, null, false)
+    new() = AdjectiveComparative(AdjectiveComparative.Default)
 
-    member val Positive = positive with get, set
-    member val Comparatives = comparatives with get, set
-    member val IsRegular = isRegular with get, set
+    [<SerializeObject>] member val Positive = model.Positive with get, set
+    [<SerializeObject>] member val Comparatives = model.Comparatives with get, set
+                        member val IsRegular = model.IsRegular with get, set

--- a/src/Storage/ExerciseModels/AdjectivePlural.fs
+++ b/src/Storage/ExerciseModels/AdjectivePlural.fs
@@ -1,14 +1,14 @@
 ﻿module AdjectivePlural
 
-open Microsoft.WindowsAzure.Storage.Table
+open Exercises
+open Storage
+open Defaults
 
-type AdjectivePlural(word: string,
-                     singular: string,
-                     plural: string) =
+type AdjectivePlural(model: Exercises.AdjectivePlural) =
 
-    inherit TableEntity(word, word)
+    inherit BaseEntity.BaseEntity(model.Id)
     
-    new() = AdjectivePlural(null, null, null)
+    new() = AdjectivePlural(AdjectivePlural.Default)
 
-    member val Singular = singular with get, set
-    member val Plural = plural with get, set
+    [<SerializeObject>] member val Singular = model.Singular with get, set
+    [<SerializeObject>] member val Plural = model.Plural with get, set

--- a/src/Storage/ExerciseModels/BaseEntity.fs
+++ b/src/Storage/ExerciseModels/BaseEntity.fs
@@ -1,0 +1,54 @@
+﻿module BaseEntity
+
+open Microsoft.WindowsAzure.Storage.Table
+open Storage
+open Newtonsoft.Json
+open StringHelper
+open System.Reflection
+open System
+open Reflection
+
+let private serializeObject = JsonConvert.SerializeObject
+let private serializeString = string
+let private serializeOption = function 
+    | null -> ""
+    | value -> value.ToString() |> removeMany ["Some(" ; ")"]
+
+let private serializationMap = 
+    dict [ (typeof<SerializeObject>, serializeObject) 
+           (typeof<SerializeString>, serializeString)
+           (typeof<SerializeOption>, serializeOption) ] 
+
+type BaseEntity(key) = 
+
+    inherit TableEntity(key, key)
+
+    override this.WriteEntity(context) = 
+        let entityProperties = base.WriteEntity(context)
+        let typeProperties = this.GetType().GetProperties()
+
+        let serialize prop =
+            let attribute = getAttribute prop
+            let rawValue = this |> getValue prop
+            serializationMap.[attribute] rawValue
+
+        typeProperties
+        |> Seq.where hasAttributes
+        |> Seq.map (fun prop -> prop.Name, serialize prop)
+        |> Seq.iter (fun (name, value) -> entityProperties.[name] <- EntityProperty(value))
+
+        entityProperties
+
+    override this.ReadEntity(entityProperties, context) =
+        base.ReadEntity(entityProperties, context)
+        let typeProperties = this.GetType().GetProperties()
+
+        let deserialize (property: PropertyInfo) = 
+            let stringValue = entityProperties.[property.Name].StringValue
+            let ``type`` = property.PropertyType
+            JsonConvert.DeserializeObject(stringValue, ``type``)
+
+        typeProperties
+        |> Seq.where (hasAttribute typeof<SerializeObject>)
+        |> Seq.map (fun prop -> prop, deserialize prop)
+        |> Seq.iter (fun (prop, value) -> this |> setValue prop value)

--- a/src/Storage/ExerciseModels/NounAccusative.fs
+++ b/src/Storage/ExerciseModels/NounAccusative.fs
@@ -1,18 +1,16 @@
 ﻿module NounAccusative
 
-open Microsoft.WindowsAzure.Storage.Table
+open Exercises
+open Storage
+open Defaults
 
-type NounAccusative(word: string,
-                    nominative: string,
-                    accusatives: string,
-                    gender: string,
-                    patterns: string) =
+type NounAccusative(model: Exercises.NounAccusative) =
 
-    inherit TableEntity(word, word)
+    inherit BaseEntity.BaseEntity(model.Id)
 
-    new() = NounAccusative(null, null, null, null, null)
+    new() = NounAccusative(NounAccusative.Default)
 
-    member val Nominative = nominative with get, set
-    member val Accusatives = accusatives with get, set
-    member val Gender = gender with get, set
-    member val Patterns = patterns with get, set
+    [<SerializeObject>] member val Nominative = model.Nominative with get, set
+    [<SerializeObject>] member val Accusatives = model.Accusatives with get, set
+    [<SerializeOption>] member val Gender = model.Gender with get, set
+    [<SerializeObject>] member val Patterns = model.Patterns with get, set

--- a/src/Storage/ExerciseModels/NounPlural.fs
+++ b/src/Storage/ExerciseModels/NounPlural.fs
@@ -1,18 +1,16 @@
 ﻿module NounPlural
 
-open Microsoft.WindowsAzure.Storage.Table
+open Exercises
+open Storage
+open Defaults
 
-type NounPlural(word: string, 
-                singular: string,
-                plurals: string, 
-                gender: string, 
-                patterns: string) =
+type NounPlural(model: Exercises.NounPlural) =
 
-    inherit TableEntity(word, word)
+    inherit BaseEntity.BaseEntity(model.Id)
     
-    new() = NounPlural(null, null, null, null, null)
+    new() = NounPlural(NounPlural.Default)
 
-    member val Singular = singular with get, set
-    member val Plurals = plurals with get, set
-    member val Gender = gender with get, set
-    member val Patterns = patterns with get, set
+    [<SerializeObject>] member val Singular = model.Singular with get, set
+    [<SerializeObject>] member val Plurals = model.Plurals with get, set
+    [<SerializeOption>] member val Gender = model.Gender with get, set
+    [<SerializeObject>] member val Patterns = model.Patterns with get, set

--- a/src/Storage/ExerciseModels/VerbConjugation.fs
+++ b/src/Storage/ExerciseModels/VerbConjugation.fs
@@ -1,27 +1,21 @@
 module VerbConjugation
 
-open Microsoft.WindowsAzure.Storage.Table
+open Exercises
+open Storage
+open Defaults
 
-type VerbConjugation(word: string,
-                     infinitive: string,
-                     pattern: string,
-                     firstSingular: string,
-                     secondSingular: string,
-                     thirdSingular: string,
-                     firstPlural: string,
-                     secondPlural: string,
-                     thirdPlural: string) =
+type VerbConjugation(model: Exercises.VerbConjugation) =
 
-    inherit TableEntity(word, word)
-     
-    new() =  VerbConjugation(null, null, null, null, null, null, null, null, null)
-
-    member val Infinitive = infinitive with get, set
-    member val Pattern = pattern with get, set
+    inherit BaseEntity.BaseEntity(model.Id)
     
-    member val FirstSingular = firstSingular with get, set
-    member val SecondSingular = secondSingular with get, set
-    member val ThirdSingular = thirdSingular with get, set
-    member val FirstPlural = firstPlural with get, set
-    member val SecondPlural = secondPlural with get, set
-    member val ThirdPlural = thirdPlural with get, set
+    new() = VerbConjugation(VerbConjugation.Default)
+
+    [<SerializeObject>] member val Infinitive = model.Infinitive with get, set
+    [<SerializeString>] member val Pattern = model.Pattern with get, set
+    
+    [<SerializeObject>] member val FirstSingular = model.Conjugation.FirstSingular with get, set
+    [<SerializeObject>] member val SecondSingular = model.Conjugation.SecondSingular with get, set
+    [<SerializeObject>] member val ThirdSingular = model.Conjugation.ThirdSingular with get, set
+    [<SerializeObject>] member val FirstPlural = model.Conjugation.FirstPlural with get, set
+    [<SerializeObject>] member val SecondPlural = model.Conjugation.SecondPlural with get, set
+    [<SerializeObject>] member val ThirdPlural = model.Conjugation.ThirdPlural with get, set

--- a/src/Storage/ExerciseModels/VerbImperative.fs
+++ b/src/Storage/ExerciseModels/VerbImperative.fs
@@ -1,18 +1,16 @@
 ﻿module VerbImperative
 
-open Microsoft.WindowsAzure.Storage.Table
+open Exercises
+open Storage
+open Defaults
 
-type VerbImperative(word: string,
-                    indicative: string,
-                    imperatives: string,
-                    ``class``: string,
-                    pattern: string) =
+type VerbImperative(model: Exercises.VerbImperative) =
 
-    inherit TableEntity(word, word)
+    inherit BaseEntity.BaseEntity(model.Id)
 
-    new() = VerbImperative(null, null, null, null, null)
+    new() = VerbImperative(VerbImperative.Default)
 
-    member val Indicative = indicative with get, set
-    member val Imperatives = imperatives with get, set
-    member val Class = ``class`` with get, set
-    member val Pattern = pattern with get, set
+    [<SerializeObject>] member val Indicative = model.Indicative with get, set
+    [<SerializeObject>] member val Imperatives = model.Imperatives with get, set
+    [<SerializeOption>] member val Class = model.Class with get, set
+    [<SerializeOption>] member val Pattern = model.Pattern with get, set

--- a/src/Storage/ExerciseModels/VerbParticiple.fs
+++ b/src/Storage/ExerciseModels/VerbParticiple.fs
@@ -1,18 +1,16 @@
 ﻿module VerbParticiple
 
-open Microsoft.WindowsAzure.Storage.Table
+open Exercises
+open Storage
+open Defaults
 
-type VerbParticiple(word: string,
-                    infinitive: string,
-                    participles: string,
-                    pattern: string,
-                    isRegular: bool) =
+type VerbParticiple(model: Exercises.VerbParticiple) =
 
-    inherit TableEntity(word, word)
+    inherit BaseEntity.BaseEntity(model.Id)
 
-    new() =  VerbParticiple(null, null, null, null, false)
+    new() = VerbParticiple(VerbParticiple.Default)
 
-    member val Infinitive = infinitive with get, set
-    member val Participles = participles with get, set
-    member val Pattern = pattern with get, set
-    member val IsRegular = isRegular with get, set
+    [<SerializeObject>] member val Infinitive = model.Infinitive with get, set
+    [<SerializeObject>] member val Participles = model.Participles with get, set
+    [<SerializeString>] member val Pattern = model.Pattern with get, set
+                        member val IsRegular = model.IsRegular with get, set

--- a/src/Storage/Reflection.fs
+++ b/src/Storage/Reflection.fs
@@ -1,0 +1,19 @@
+﻿module Reflection
+
+open System
+open System.Reflection
+
+let hasAttribute (attributeType: Type) (prop: PropertyInfo) = 
+    prop.GetCustomAttributes(attributeType) |> Seq.any
+
+let hasAttributes (prop: PropertyInfo) = 
+    prop.GetCustomAttributes() |> Seq.any
+
+let getAttributes (prop: PropertyInfo) = 
+    prop.GetCustomAttributes() |> Seq.map (fun a -> a.GetType())
+
+let getAttribute prop = prop |> getAttributes |> Seq.exactlyOne
+
+let getValue (prop: PropertyInfo) entity = prop.GetValue entity
+
+let setValue (prop: PropertyInfo) value entity = prop.SetValue(entity, value)

--- a/src/Storage/Storage.fs
+++ b/src/Storage/Storage.fs
@@ -32,11 +32,9 @@ type QueryCondition =
     | Int
     | String
 
-let serializeObject = JsonConvert.SerializeObject
-let serializeString = string
-let serializeOption<'T> : ('T option -> string) = function | Some v -> v.ToString() | None -> ""
-
-let getAs<'T> = JsonConvert.DeserializeObject<'T>
+type SerializeObject() = inherit Attribute()
+type SerializeString() = inherit Attribute()
+type SerializeOption() = inherit Attribute()
 
 let getTable name =
     async {

--- a/src/Storage/Storage.fsproj
+++ b/src/Storage/Storage.fsproj
@@ -10,7 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Defaults.fs" />
+    <Compile Include="Reflection.fs" />
     <Compile Include="Storage.fs" />
+    <Compile Include="ExerciseModels\BaseEntity.fs" />
     <Compile Include="ExerciseModels\VerbConjugation.fs" />
     <Compile Include="ExerciseModels\VerbImperative.fs" />
     <Compile Include="ExerciseModels\VerbParticiple.fs" />


### PR DESCRIPTION
The idea is to have exercise models in terms of the domain types. They are now in the Common/Exercises module.

The translation to Azure Table Storage types (which are limited to string, bool and a few others) is done at the very end via attributes so that the entity modules look more clear and succinct.

The reflection magic is done in `BaseEntity` and is inspired by this [article](https://blog.bitscry.com/2019/04/12/adding-complex-properties-of-a-tableentity-to-azure-table-storage/). Everything else is repetitive - no business logic is needed.