### PR TITLE
Generalized noun declension exercise - backend (#653)

### DIFF
--- a/src/Common/Exercises.fs
+++ b/src/Common/Exercises.fs
@@ -2,6 +2,13 @@
 
 open GrammarCategories
 
+type Noun = {
+    Id: string
+    Gender: Gender option
+    Patterns: seq<string>
+    Declension: Declension
+}
+
 type NounPlural = {
     Id: string
     Singular: string

--- a/src/Common/GrammarCategories.fs
+++ b/src/Common/GrammarCategories.fs
@@ -25,3 +25,20 @@ type Declinability =
 
 type Person = 
     | First | Second | Third
+
+type Declension = {
+    SingularNominative: seq<string>
+    SingularGenitive: seq<string>
+    SingularDative: seq<string>
+    SingularAccusative: seq<string>
+    SingularVocative: seq<string>
+    SingularLocative: seq<string>
+    SingularInstrumental: seq<string>
+    PluralNominative: seq<string>
+    PluralGenitive: seq<string>
+    PluralDative: seq<string>
+    PluralAccusative: seq<string>
+    PluralVocative: seq<string>
+    PluralLocative: seq<string>
+    PluralInstrumental: seq<string>
+}

--- a/src/Scraper/Word.fs
+++ b/src/Scraper/Word.fs
@@ -11,6 +11,7 @@ let registerIfValid parse register =
 
 let recordCzechPartOfSpeech article = function
     | "podstatné jméno" -> [
+        article |> registerIfValid NounValidation.parseNoun NounRegistration.registerNoun
         article |> registerIfValid NounValidation.parseNounPlural NounRegistration.registerNounPlural
         article |> registerIfValid NounValidation.parseNounAccusative NounRegistration.registerNounAccusative
       ]

--- a/src/Scraper/WordRegistration/NounRegistration.fs
+++ b/src/Scraper/WordRegistration/NounRegistration.fs
@@ -6,6 +6,31 @@ open GrammarCategories
 open WikiArticles
 open Exercises
 
+let registerNoun nounArticle =
+    let (NounArticle { Title = word }) = nounArticle
+
+    upsert "nouns" (Noun.Noun {
+        Id = word
+        Gender = nounArticle |> getGender
+        Patterns = nounArticle |> getPatterns
+        Declension = {
+            SingularNominative = nounArticle |> getDeclension Case.Nominative Number.Singular
+            SingularGenitive = nounArticle |> getDeclension Case.Genitive Number.Singular
+            SingularDative = nounArticle |> getDeclension Case.Dative Number.Singular
+            SingularAccusative = nounArticle |> getDeclension Case.Accusative Number.Singular
+            SingularVocative = nounArticle |> getDeclension Case.Vocative Number.Singular
+            SingularLocative = nounArticle |> getDeclension Case.Locative Number.Singular
+            SingularInstrumental = nounArticle |> getDeclension Case.Instrumental Number.Singular
+            PluralNominative = nounArticle |> getDeclension Case.Nominative Number.Plural
+            PluralGenitive = nounArticle |> getDeclension Case.Genitive Number.Plural
+            PluralDative = nounArticle |> getDeclension Case.Dative Number.Plural
+            PluralAccusative = nounArticle |> getDeclension Case.Accusative Number.Plural
+            PluralVocative = nounArticle |> getDeclension Case.Vocative Number.Plural
+            PluralLocative = nounArticle |> getDeclension Case.Locative Number.Plural
+            PluralInstrumental = nounArticle |> getDeclension Case.Instrumental Number.Plural
+        }
+    })
+
 let registerNounPlural nounArticleWithPlural =
     let (NounArticleWithPlural nounArticle) = nounArticleWithPlural
     let (NounArticle { Title = word }) = nounArticle

--- a/src/Storage/Defaults.fs
+++ b/src/Storage/Defaults.fs
@@ -2,6 +2,29 @@
 
 open Exercises
 
+type Noun with 
+    static member Default = {
+        Id = null
+        Gender = None
+        Patterns = null
+        Declension = {
+            SingularNominative = null
+            SingularGenitive = null
+            SingularDative = null
+            SingularAccusative = null
+            SingularVocative = null
+            SingularLocative = null
+            SingularInstrumental = null
+            PluralNominative = null
+            PluralGenitive = null
+            PluralDative = null
+            PluralAccusative = null
+            PluralVocative = null
+            PluralLocative = null
+            PluralInstrumental = null
+        }
+    }
+
 type NounPlural with 
     static member Default = {
         Id = null

--- a/src/Storage/ExerciseModels/Noun.fs
+++ b/src/Storage/ExerciseModels/Noun.fs
@@ -1,0 +1,29 @@
+﻿module Noun
+
+open Exercises
+open Storage
+open Defaults
+
+type Noun(model: Exercises.Noun) = 
+    
+    inherit BaseEntity.BaseEntity(model.Id)
+
+    new() = Noun(Noun.Default)
+
+    [<SerializeOption>] member val Gender = model.Gender with get, set
+    [<SerializeObject>] member val Patterns = model.Patterns with get, set
+
+    [<SerializeObject>] member val SingularNominative = model.Declension.SingularNominative with get, set
+    [<SerializeObject>] member val SingularGenitive = model.Declension.SingularGenitive with get, set
+    [<SerializeObject>] member val SingularDative = model.Declension.SingularDative with get, set
+    [<SerializeObject>] member val SingularAccusative = model.Declension.SingularAccusative with get, set
+    [<SerializeObject>] member val SingularLocative = model.Declension.SingularVocative with get, set
+    [<SerializeObject>] member val SingularVocative = model.Declension.SingularLocative with get, set
+    [<SerializeObject>] member val SingularInstrumental = model.Declension.SingularInstrumental with get, set
+    [<SerializeObject>] member val PluralNominative = model.Declension.PluralNominative with get, set
+    [<SerializeObject>] member val PluralGenitive = model.Declension.PluralGenitive with get, set
+    [<SerializeObject>] member val PluralDative = model.Declension.PluralDative with get, set
+    [<SerializeObject>] member val PluralAccusative = model.Declension.PluralAccusative with get, set
+    [<SerializeObject>] member val PluralLocative = model.Declension.PluralVocative with get, set
+    [<SerializeObject>] member val PluralVocative = model.Declension.PluralLocative with get, set
+    [<SerializeObject>] member val PluralInstrumental = model.Declension.PluralInstrumental with get, set

--- a/src/Storage/Storage.fsproj
+++ b/src/Storage/Storage.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="ExerciseModels\VerbParticiple.fs" />
     <Compile Include="ExerciseModels\AdjectiveComparative.fs" />
     <Compile Include="ExerciseModels\AdjectivePlural.fs" />
+    <Compile Include="ExerciseModels\Noun.fs" />
     <Compile Include="ExerciseModels\NounAccusative.fs" />
     <Compile Include="ExerciseModels\NounPlural.fs" />
   </ItemGroup>


### PR DESCRIPTION
So we are moving to the next exercise where users can decline nouns for all the cases.

Here are mostly the backend changes - new table, new model and so on. The correct validation was already there. For now I did not remove anything to not mess up the PR but this will be the next step.

Minor frontend changes include retrieving results from the new table. The case filters are added so that we get only those nouns that have the cases that we need.