### PR TITLE
Simplified noun pattern detection (#673)

### DIFF
--- a/src/Core/Nouns/FeminineNounPatternDetector.fs
+++ b/src/Core/Nouns/FeminineNounPatternDetector.fs
@@ -1,34 +1,33 @@
 ﻿module Core.Nouns.FeminineNounPatternDetector
 
-open WikiParsing.Articles.NounArticle
 open Common.StringHelper
 open Common.GrammarCategories
 open Core.Stem
 
-let isPatternŽena article = 
-    let nominatives = article |> getDeclension Case.Nominative Number.Singular
-    let genitives = article |> getDeclension Case.Genitive Number.Singular
+let isPatternŽena declension = 
+    let nominatives = declension.SingularNominative
+    let genitives = declension.SingularGenitive
 
     nominatives |> Seq.exists (ends "a") && 
     genitives |> Seq.exists (endsOneOf ["y"; "i"])
 
-let isPatternRůže article =
-    let nominatives = article |> getDeclension Case.Nominative Number.Singular
-    let genitives = article |> getDeclension Case.Genitive Number.Singular
+let isPatternRůže declension =
+    let nominatives = declension.SingularNominative
+    let genitives = declension.SingularGenitive
 
     nominatives |> Seq.exists (endsOneOf ["e"; "ě"; "a"]) && 
     genitives |> Seq.exists (endsOneOf ["e"; "ě"])
 
-let isPatternPíseň article =
-    let nominatives = article |> getDeclension Case.Nominative Number.Singular
-    let genitives = article |> getDeclension Case.Genitive Number.Singular
+let isPatternPíseň declension =
+    let nominatives = declension.SingularNominative
+    let genitives = declension.SingularGenitive
 
     nominatives |> Seq.exists endsConsonant &&
     genitives |> Seq.exists (endsOneOf ["e"; "ě"])
 
-let isPatternKost article =
-    let datives = article |> getDeclension Case.Dative Number.Plural
-    let instrumentals = article |> getDeclension Case.Instrumental Number.Plural
+let isPatternKost declension =
+    let datives = declension.PluralDative
+    let instrumentals = declension.PluralInstrumental
 
     datives |> Seq.exists (ends "em") &&
     instrumentals |> Seq.exists (not << endsOneOf ["emi"; "ěmi"])

--- a/src/Core/Nouns/MasculineAnimateNounPatternDetector.fs
+++ b/src/Core/Nouns/MasculineAnimateNounPatternDetector.fs
@@ -1,28 +1,27 @@
 ﻿module Core.Nouns.MasculineAnimateNounPatternDetector
 
-open WikiParsing.Articles.NounArticle
 open Common.StringHelper
 open Common.GrammarCategories
 open Core.Stem
 
-let isPatternPán = 
-    getDeclension Case.Genitive Number.Singular
-    >> Seq.exists (ends "a")
+let isPatternPán declension = 
+    declension.SingularGenitive
+    |> Seq.exists (ends "a")
 
-let isPatternMuž article =
-    let nominatives = article |> getDeclension Case.Nominative Number.Singular
-    let genitives = article |> getDeclension Case.Genitive Number.Singular
+let isPatternMuž declension =
+    let nominatives = declension.SingularNominative
+    let genitives = declension.SingularGenitive
 
     nominatives |> Seq.exists (endsSoft) &&
     genitives |> Seq.exists (endsOneOf ["e"; "ě"])
 
-let isPatternPředseda =
-    getDeclension Case.Nominative Number.Singular
-    >> Seq.exists (ends "a")
+let isPatternPředseda declension =
+    declension.SingularNominative
+    |> Seq.exists (ends "a")
 
-let isPatternSoudce =
-    getDeclension Case.Nominative Number.Singular
-    >> Seq.exists (ends "ce")
+let isPatternSoudce declension =
+    declension.SingularNominative
+    |> Seq.exists (ends "ce")
 
 let patternDetectors = [
     (isPatternPán, "pán")

--- a/src/Core/Nouns/MasculineInanimateNounPatternDetector.fs
+++ b/src/Core/Nouns/MasculineInanimateNounPatternDetector.fs
@@ -1,39 +1,33 @@
 ﻿module Core.Nouns.MasculineInanimateNounPatternDetector
 
-open WikiParsing.Articles.NounArticle
 open Common.StringHelper
 open Common.GrammarCategories
-open Common.WikiArticles
 
 let canBeLoanword = endsOneOf ["us"; "es"; "os"]
 
-let isPatternHrad article = 
-    let (NounArticle { Title = noun }) = article
-    match article with
-    | article when noun |> canBeLoanword -> 
-        let singulars = article |> getDeclension Case.Nominative Number.Singular
-        let plurals = article |> getDeclension Case.Nominative Number.Plural
-        
+let isPatternHrad declension = 
+    if declension.SingularNominative |> Seq.exists canBeLoanword
+    then
+        let singulars = declension.SingularNominative
+        let plurals = declension.PluralNominative
+
         let isPluralPatternHrad (singular, plural) = 
             singular |> append "y" = plural
 
         Seq.allPairs singulars plurals |> Seq.exists isPluralPatternHrad
-    | article ->
-        article
-        |> getDeclension Case.Genitive Number.Singular
+    else
+        declension.SingularGenitive
         |> Seq.exists (endsOneOf ["u"; "a"])
 
-let isPatternStroj =
-    getDeclension Case.Nominative Number.Plural
-    >> Seq.exists (endsOneOf ["e"; "ě"])
+let isPatternStroj declension =
+    declension.PluralNominative
+    |> Seq.exists (endsOneOf ["e"; "ě"])
 
-let isPatternRytmus article =
-    let (NounArticle { Title = noun }) = article
+let isPatternRytmus declension =
+    declension.SingularNominative |> Seq.exists canBeLoanword && 
 
-    noun |> canBeLoanword && 
-
-    let singulars = article |> getDeclension Case.Nominative Number.Singular
-    let plurals = article |> getDeclension Case.Nominative Number.Plural
+    let singulars = declension.SingularNominative
+    let plurals = declension.PluralNominative
 
     let isPluralPatternRytmus (singular, plural) = 
         singular |> removeLast 2 |> append "y" = plural

--- a/src/Core/Nouns/NeuterNounPatternDetector.fs
+++ b/src/Core/Nouns/NeuterNounPatternDetector.fs
@@ -1,48 +1,47 @@
 ﻿module Core.Nouns.NeuterNounPatternDetector
 
-open WikiParsing.Articles.NounArticle
 open Common.StringHelper
 open Common.GrammarCategories
 open Core.Letters
 open Core.Stem
 
-let isPatternMěsto article = 
-    let nominatives = article |> getDeclension Case.Nominative Number.Singular
-    let genitives = article |> getDeclension Case.Genitive Number.Plural
+let isPatternMěsto declension = 
+    let nominatives = declension.SingularNominative
+    let genitives = declension.PluralGenitive
     
     nominatives |> Seq.exists (ends "o") &&
     genitives |> Seq.exists (endsConsonant)
 
-let isPatternMoře article =
-    let singulars = article |> getDeclension Case.Nominative Number.Singular
-    let plurals = article |> getDeclension Case.Nominative Number.Plural
+let isPatternMoře declension =
+    let singulars = declension.SingularNominative
+    let plurals = declension.PluralNominative
 
     singulars |> Seq.exists (endsOneOf ["e"; "ě"]) &&
     plurals |> Seq.exists (endsOneOf ["e"; "ě"])
 
-let isPatternStavení =
-    getDeclension Case.Genitive Number.Singular
-    >> Seq.exists (ends "í")
+let isPatternStavení declension =
+    declension.SingularGenitive
+    |> Seq.exists (ends "í")
 
-let isPatternKuře article =
-    let singulars = article |> getDeclension Case.Nominative Number.Singular
-    let plurals = article |> getDeclension Case.Nominative Number.Plural
+let isPatternKuře declension =
+    let singulars = declension.SingularNominative
+    let plurals = declension.PluralNominative
 
     singulars |> Seq.exists (endsOneOf ["e"; "ě"]) &&
     plurals |> Seq.exists (ends "ata")
 
-let isPatternDrama article =
-    let singulars = article |> getDeclension Case.Nominative Number.Singular
-    let plurals = article |> getDeclension Case.Nominative Number.Plural
+let isPatternDrama declension =
+    let singulars = declension.SingularNominative
+    let plurals = declension.PluralNominative
 
     singulars |> Seq.exists (ends "ma") &&
     plurals |> Seq.exists (ends "mata")
 
-let isPatternMuzeum article =
+let isPatternMuzeum declension =
     let stemEndsVowel = remove "um" >> Seq.last >> isVowel
     let rule word = word |> ends "um" && word |> stemEndsVowel
 
-    let singulars = article |> getDeclension Case.Nominative Number.Singular
+    let singulars = declension.SingularNominative
     singulars |> Seq.exists rule
 
 let patternDetectors = [

--- a/src/Core/Nouns/Noun.fs
+++ b/src/Core/Nouns/Noun.fs
@@ -10,5 +10,5 @@ let getGender =
 let getPatterns = 
     NounPatterns.getPatterns 
 
-let getDeclension case number = 
-    NounArticle.getDeclension case number
+let getDeclension = 
+    NounArticle.getDeclension

--- a/src/Core/Nouns/NounPatterns.fs
+++ b/src/Core/Nouns/NounPatterns.fs
@@ -10,7 +10,7 @@ let patternsGenderMap =
            (Feminine, FeminineNounPatternDetector.getPatterns)
            (Neuter, NeuterNounPatternDetector.getPatterns) ]
 
-let getPatternsByGender word gender = patternsGenderMap.[gender] word
+let getPatternsByGender declension gender = patternsGenderMap.[gender] declension
 
 let getPatterns article = 
     match article |> getDeclinability with
@@ -20,5 +20,5 @@ let getPatterns article =
         article
         |> getGender
         |> Option.map fromString
-        |> Option.map (getPatternsByGender article)
+        |> Option.map (getPatternsByGender (article |> getDeclension))
         |> Option.defaultValue Seq.empty

--- a/src/Scraper/WordRegistration/NounRegistration.fs
+++ b/src/Scraper/WordRegistration/NounRegistration.fs
@@ -3,7 +3,6 @@
 open Storage.Storage
 open Storage.ExerciseModels.Noun
 open Core.Nouns.Noun
-open Common.GrammarCategories
 open Common.WikiArticles
 open Common.Exercises
 
@@ -14,20 +13,5 @@ let registerNoun nounArticle =
         Id = word
         Gender = nounArticle |> getGender
         Patterns = nounArticle |> getPatterns
-        Declension = {
-            SingularNominative = nounArticle |> getDeclension Case.Nominative Number.Singular
-            SingularGenitive = nounArticle |> getDeclension Case.Genitive Number.Singular
-            SingularDative = nounArticle |> getDeclension Case.Dative Number.Singular
-            SingularAccusative = nounArticle |> getDeclension Case.Accusative Number.Singular
-            SingularVocative = nounArticle |> getDeclension Case.Vocative Number.Singular
-            SingularLocative = nounArticle |> getDeclension Case.Locative Number.Singular
-            SingularInstrumental = nounArticle |> getDeclension Case.Instrumental Number.Singular
-            PluralNominative = nounArticle |> getDeclension Case.Nominative Number.Plural
-            PluralGenitive = nounArticle |> getDeclension Case.Genitive Number.Plural
-            PluralDative = nounArticle |> getDeclension Case.Dative Number.Plural
-            PluralAccusative = nounArticle |> getDeclension Case.Accusative Number.Plural
-            PluralVocative = nounArticle |> getDeclension Case.Vocative Number.Plural
-            PluralLocative = nounArticle |> getDeclension Case.Locative Number.Plural
-            PluralInstrumental = nounArticle |> getDeclension Case.Instrumental Number.Plural
-        }
+        Declension = nounArticle |> getDeclension
     })

--- a/src/WikiParsing/Articles/NounArticle.fs
+++ b/src/WikiParsing/Articles/NounArticle.fs
@@ -99,10 +99,28 @@ let getDeclensionWiki (case: Case) number nounArticle =
     | word -> 
         invalidOp ("Odd word: " + word)
 
-let getDeclension case number = 
+let private getPartialDeclension case number = 
     getDeclensionWiki case number 
     >> Seq.collect getForms
     >> Seq.distinct
+
+let getDeclension article = 
+    {
+        SingularNominative = article |> getPartialDeclension Case.Nominative Number.Singular
+        SingularGenitive = article |> getPartialDeclension Case.Genitive Number.Singular
+        SingularDative = article |> getPartialDeclension Case.Dative Number.Singular
+        SingularAccusative = article |> getPartialDeclension Case.Accusative Number.Singular
+        SingularVocative = article |> getPartialDeclension Case.Vocative Number.Singular
+        SingularLocative = article |> getPartialDeclension Case.Locative Number.Singular
+        SingularInstrumental = article |> getPartialDeclension Case.Instrumental Number.Singular
+        PluralNominative = article |> getPartialDeclension Case.Nominative Number.Plural
+        PluralGenitive = article |> getPartialDeclension Case.Genitive Number.Plural
+        PluralDative = article |> getPartialDeclension Case.Dative Number.Plural
+        PluralAccusative = article |> getPartialDeclension Case.Accusative Number.Plural
+        PluralVocative = article |> getPartialDeclension Case.Vocative Number.Plural
+        PluralLocative = article |> getPartialDeclension Case.Locative Number.Plural
+        PluralInstrumental = article |> getPartialDeclension Case.Instrumental Number.Plural
+    }
 
 let getGender (NounArticle article) =
     article

--- a/tests/Core.IntegrationTests/FeminineNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/FeminineNounPatternDetectorTests.fs
@@ -4,17 +4,19 @@ open Xunit
 
 open Core.Nouns.FeminineNounPatternDetector
 open Common.WikiArticles
+open WikiParsing.Articles.NounArticle
 
-let getArticle =
+let getDeclension =
     getArticle
     >> NounArticle
+    >> getDeclension
 
 [<Theory>]
 [<InlineData "holka">]
 [<InlineData "dača">]
 let ``Detects pattern žena`` word =
     word
-    |> getArticle 
+    |> getDeclension
     |> isPatternŽena
     |> Assert.True
 
@@ -26,7 +28,7 @@ let ``Detects pattern žena`` word =
 [<InlineData "micve">]
 let ``Detects not pattern žena`` word =
     word
-    |> getArticle 
+    |> getDeclension 
     |> isPatternŽena
     |> Assert.False
 
@@ -39,7 +41,7 @@ let ``Detects not pattern žena`` word =
 [<InlineData "paranoia">]
 let ``Detects pattern růže`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternRůže
     |> Assert.True
 
@@ -50,7 +52,7 @@ let ``Detects pattern růže`` word =
 [<InlineData "noc">]
 let ``Detects not pattern růže`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternRůže
     |> Assert.False
 
@@ -64,7 +66,7 @@ let ``Detects not pattern růže`` word =
 [<InlineData "pouť">]
 let ``Detects pattern píseň`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternPíseň
     |> Assert.True
     
@@ -79,7 +81,7 @@ let ``Detects pattern píseň`` word =
 [<InlineData "lest">]
 let ``Detects not pattern píseň`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternPíseň
     |> Assert.False
     
@@ -93,7 +95,7 @@ let ``Detects not pattern píseň`` word =
 [<InlineData "paměť">]
 let ``Detects pattern kost`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternKost
     |> Assert.True
 
@@ -108,7 +110,7 @@ let ``Detects pattern kost`` word =
 [<InlineData "myš">]
 let ``Detects not pattern kost`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternKost
     |> Assert.False
 
@@ -120,7 +122,7 @@ let ``Detects not pattern kost`` word =
 [<InlineData "noc">]
 let ``Detects no patterns`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> getPatterns
     |> Seq.isEmpty
     |> Assert.True

--- a/tests/Core.IntegrationTests/MasculineAnimateNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/MasculineAnimateNounPatternDetectorTests.fs
@@ -5,10 +5,12 @@ open Xunit
 open Core.Nouns.MasculineAnimateNounPatternDetector
 open Common.WikiArticles
 open Common
+open WikiParsing.Articles.NounArticle
 
-let getArticle =
+let getDeclension =
     getArticle
     >> NounArticle
+    >> getDeclension
 
 [<Theory>]
 [<InlineData "syn">]
@@ -18,7 +20,7 @@ let getArticle =
 [<InlineData "geolog">]
 let ``Detects pattern pán`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternPán
     |> Assert.True
 
@@ -29,7 +31,7 @@ let ``Detects pattern pán`` word =
 [<InlineData "dárce">]
 let ``Detects not pattern pán`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternPán
     |> Assert.False
 
@@ -43,7 +45,7 @@ let ``Detects not pattern pán`` word =
 [<InlineData "Felix">]
 let ``Detects pattern muž`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternMuž
     |> Assert.True
 
@@ -54,7 +56,7 @@ let ``Detects pattern muž`` word =
 [<InlineData "vůdce">]
 let ``Detects not pattern muž`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternMuž
     |> Assert.False
 
@@ -67,7 +69,7 @@ let ``Detects not pattern muž`` word =
 [<InlineData "Honza">]
 let ``Detects pattern předseda`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternPředseda
     |> Assert.True
     
@@ -77,7 +79,7 @@ let ``Detects pattern předseda`` word =
 [<InlineData "vůdce">]
 let ``Detects not pattern předseda`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternPředseda
     |> Assert.False
     
@@ -86,7 +88,7 @@ let ``Detects not pattern předseda`` word =
 [<InlineData "dárce">]
 let ``Detects pattern soudce`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternSoudce
     |> Assert.True
 
@@ -96,7 +98,7 @@ let ``Detects pattern soudce`` word =
 [<InlineData "kolega">]
 let ``Detects not pattern soudce`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternSoudce
     |> Assert.False
 
@@ -106,7 +108,7 @@ let ``Detects not pattern soudce`` word =
 [<InlineData "boss">]
 let ``Detects multiple patterns`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> getPatterns
     |> Seq.containsMultiple
     |> Assert.True
@@ -116,7 +118,7 @@ let ``Detects multiple patterns`` word =
 [<InlineData "George">]
 let ``Detects no patterns`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> getPatterns
     |> Seq.isEmpty
     |> Assert.True

--- a/tests/Core.IntegrationTests/MasculineInanimateNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/MasculineInanimateNounPatternDetectorTests.fs
@@ -5,10 +5,12 @@ open Xunit
 open Core.Nouns.MasculineInanimateNounPatternDetector
 open Common.WikiArticles
 open Common
+open WikiParsing.Articles.NounArticle
 
-let getArticle =
+let getDeclension =
     getArticle
     >> NounArticle
+    >> getDeclension
 
 [<Theory>]
 [<InlineData "strom">]
@@ -22,7 +24,7 @@ let getArticle =
 [<InlineData "týl">]
 let ``Detects pattern hrad`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternHrad
     |> Assert.True
 
@@ -33,7 +35,7 @@ let ``Detects pattern hrad`` word =
 [<InlineData "kosmos">]
 let ``Detects not pattern hrad`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternHrad
     |> Assert.False
 
@@ -42,7 +44,7 @@ let ``Detects not pattern hrad`` word =
 [<InlineData "déšť">]
 let ``Detects pattern stroj`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternStroj
     |> Assert.True
 
@@ -55,7 +57,7 @@ let ``Detects pattern stroj`` word =
 [<InlineData "kosmos">]
 let ``Detects not pattern stroj`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternStroj
     |> Assert.False
 
@@ -65,7 +67,7 @@ let ``Detects not pattern stroj`` word =
 [<InlineData "kosmos">]
 let ``Detects pattern rytmus`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternRytmus
     |> Assert.True
 
@@ -77,7 +79,7 @@ let ``Detects pattern rytmus`` word =
 [<InlineData "stroj">]
 let ``Detects not pattern rytmus`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternRytmus
     |> Assert.False
 
@@ -88,7 +90,7 @@ let ``Detects not pattern rytmus`` word =
 [<InlineData "glóbus">]
 let ``Detects multiple patterns`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> getPatterns
     |> Seq.containsMultiple
     |> Assert.True

--- a/tests/Core.IntegrationTests/NeuterNounPatternDetectorTests.fs
+++ b/tests/Core.IntegrationTests/NeuterNounPatternDetectorTests.fs
@@ -4,17 +4,19 @@ open Xunit
 
 open Core.Nouns.NeuterNounPatternDetector
 open Common.WikiArticles
+open WikiParsing.Articles.NounArticle
 
-let getArticle =
+let getDeclension =
     getArticle
     >> NounArticle
+    >> getDeclension
 
 [<Theory>]
 [<InlineData "okno">]
 [<InlineData "slovo">]
 let ``Detects pattern město`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternMěsto
     |> Assert.True
 
@@ -29,7 +31,7 @@ let ``Detects pattern město`` word =
 [<InlineData "muzeum">]
 let ``Detects not pattern město`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternMěsto
     |> Assert.False
 
@@ -39,7 +41,7 @@ let ``Detects not pattern město`` word =
 [<InlineData "odpoledne">]
 let ``Detects pattern moře`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternMoře
     |> Assert.True
 
@@ -53,7 +55,7 @@ let ``Detects pattern moře`` word =
 [<InlineData "muzeum">]
 let ``Detects not pattern moře`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternMoře
     |> Assert.False
 
@@ -62,7 +64,7 @@ let ``Detects not pattern moře`` word =
 [<InlineData "překvapení">]
 let ``Detects pattern stavení`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternStavení
     |> Assert.True
     
@@ -72,7 +74,7 @@ let ``Detects pattern stavení`` word =
 [<InlineData "kuře">]
 let ``Detects not pattern stavení`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternStavení
     |> Assert.False
     
@@ -84,7 +86,7 @@ let ``Detects not pattern stavení`` word =
 [<InlineData "štíhle">]
 let ``Detects pattern kuře`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternKuře
     |> Assert.True
 
@@ -94,7 +96,7 @@ let ``Detects pattern kuře`` word =
 [<InlineData "okno">]
 let ``Detects not pattern kuře`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternKuře
     |> Assert.False
 
@@ -103,7 +105,7 @@ let ``Detects not pattern kuře`` word =
 [<InlineData "dilema">]
 let ``Detects pattern drama`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternDrama
     |> Assert.True
 
@@ -115,7 +117,7 @@ let ``Detects pattern drama`` word =
 [<InlineData "pyžama">]
 let ``Detects not pattern drama`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternDrama
     |> Assert.False
 
@@ -126,7 +128,7 @@ let ``Detects not pattern drama`` word =
 [<InlineData "vakuum">]
 let ``Detects pattern muzeum`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternMuzeum
     |> Assert.True
 
@@ -136,7 +138,7 @@ let ``Detects pattern muzeum`` word =
 [<InlineData "centrum">]
 let ``Detects not pattern muzeum`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> isPatternMuzeum
     |> Assert.False
 
@@ -146,7 +148,7 @@ let ``Detects not pattern muzeum`` word =
 [<InlineData "břímě">]
 let ``Detects no patterns`` word =
     word
-    |> getArticle
+    |> getDeclension
     |> getPatterns
     |> Seq.isEmpty
     |> Assert.True

--- a/tests/WikiParsing.Tests/NounArticleTests.fs
+++ b/tests/WikiParsing.Tests/NounArticleTests.fs
@@ -10,6 +10,8 @@ let getArticle =
     getArticle
     >> NounArticle
 
+let getDeclension = getArticle >> getDeclension
+
 [<Fact>]
 let ``Gets number of declensions``() =
     "starost"
@@ -41,36 +43,36 @@ let ``Gets wiki plural wiki - locked article``() =
 [<Fact>]
 let ``Gets declension - indeclinable``() =
     "dada"
-    |> getArticle
-    |> getDeclension Case.Nominative Number.Singular
+    |> getDeclension
+    |> fun declension -> declension.SingularNominative
     |> seqEquals ["dada"]
 
 [<Fact>]
 let ``Gets declension - single option``() =
     "hrad"
-    |> getArticle
-    |> getDeclension Case.Nominative Number.Singular
+    |> getDeclension
+    |> fun declension -> declension.SingularNominative
     |> seqEquals ["hrad"]
 
 [<Fact>]
 let ``Gets declension - no options``() =
     "záda"
-    |> getArticle
-    |> getDeclension Case.Nominative Number.Singular
+    |> getDeclension
+    |> fun declension -> declension.SingularNominative
     |> seqEquals []
 
 [<Fact>]
 let ``Gets declension - multiple declensions``() =
     "čtvrt"
-    |> getArticle
-    |> getDeclension Case.Nominative Number.Plural
+    |> getDeclension
+    |> fun declension -> declension.PluralNominative
     |> seqEquals ["čtvrtě"; "čtvrti"]
 
 [<Fact>]
 let ``Gets singulars - multiple options``() =
     "temeno"
-    |> getArticle
-    |> getDeclension Case.Nominative Number.Singular
+    |> getDeclension
+    |> fun declension -> declension.SingularNominative
     |> seqEquals ["temeno"; "témě"]
     
 [<Theory>]


### PR DESCRIPTION
Pattern detectors now accept `Declension` instead of the whole wiki article. That makes code and dependencies more clear - we only need a declension table to understand the pattern.

No logic is changed otherwise, basically adjustments in noun registration and tests.