### PR TITLE
Removed Ids from exercise models (#678)

### DIFF
--- a/src/Common/Exercises.fs
+++ b/src/Common/Exercises.fs
@@ -3,27 +3,23 @@
 open GrammarCategories
 
 type Noun = {
-    Id: string
     Gender: Gender option
     Patterns: seq<string>
     Declension: Declension
 }
 
 type AdjectivePlural = {
-    Id: string
     Singular: string
     Plural: string
 }
 
 type AdjectiveComparative = {
-    Id: string
     Positive: string
     Comparatives: seq<string>
     IsRegular: bool
 }
 
 type VerbImperative = {
-    Id: string
     Indicative: string
     Imperatives: seq<string>
     Class: Verbs.VerbClass option
@@ -31,7 +27,6 @@ type VerbImperative = {
 }
 
 type VerbParticiple = {
-    Id: string
     Infinitive: string
     Participles: seq<string>
     Pattern: Verbs.Pattern
@@ -39,7 +34,6 @@ type VerbParticiple = {
 }
 
 type VerbConjugation = {
-    Id: string
     Infinitive: string
     Pattern: Verbs.Pattern
     Conjugation: Conjugation.Conjugation

--- a/src/Scraper/ExerciseCreation/Adjectives.fs
+++ b/src/Scraper/ExerciseCreation/Adjectives.fs
@@ -16,11 +16,10 @@ let private hasRegularComparatives comparison =
     |> Seq.contains (comparison.Positive |> buildComparative)
 
 type AdjectiveComparative with 
-    static member Create id comparison = 
+    static member Create comparison = 
         if comparison |> morphologicalComparativeExists
         then 
             Some {
-                Id = id
                 Positive = comparison.Positive
                 Comparatives = comparison.Comparatives
                 IsRegular = comparison |> hasRegularComparatives
@@ -28,8 +27,7 @@ type AdjectiveComparative with
         else None
 
 type AdjectivePlural with 
-    static member Create id declension = {
-        Id = id
+    static member Create declension : AdjectivePlural = {
         Singular = declension.Singular
         Plural = declension.Plural
     }

--- a/src/Scraper/ExerciseCreation/Nouns.fs
+++ b/src/Scraper/ExerciseCreation/Nouns.fs
@@ -10,10 +10,9 @@ let private getPatterns noun =
     else Seq.empty
 
 type NounDeclension with 
-    static member Create id (noun: NounDeclension) = 
+    static member Create (noun: NounDeclension) = 
         if noun.Declension.IsSome 
         then Some {
-                Id = id
                 Gender = noun.Gender
                 Patterns = noun |> getPatterns
                 Declension = noun.Declension.Value

--- a/src/Scraper/ExerciseCreation/Verbs.fs
+++ b/src/Scraper/ExerciseCreation/Verbs.fs
@@ -24,20 +24,18 @@ let private getParticiplePattern = ParticiplePatternDetector.getPattern
 let private getImperativePattern = VerbPatternDetector.getPattern
 
 type VerbConjugation with 
-    static member Create id verb = 
+    static member Create verb =
         verb.Conjugation |> Option.map (fun conjugation -> 
         {
-            Id = id
             Infinitive = conjugation.Infinitive
             Pattern = verb.CanonicalForm |> getParticiplePattern
             Conjugation = conjugation.Conjugation
         })
 
 type VerbImperative with 
-    static member Create id verb =
+    static member Create verb =
         verb.Imperative |> Option.map (fun imperative -> 
         {
-            Id = id
             Indicative = imperative.Indicative
             Imperatives = imperative.Imperatives
             Class = 
@@ -51,10 +49,9 @@ type VerbImperative with
         })
 
 type VerbParticiple with 
-    static member Create id verb =
+    static member Create verb =
         verb.Participle |> Option.map (fun participle ->
         {
-            Id = id
             Infinitive = participle.Infinitive
             Participles = participle.Participles
             Pattern = verb.CanonicalForm |> getParticiplePattern

--- a/src/Scraper/WordRegistration/AdjectiveRegistration.fs
+++ b/src/Scraper/WordRegistration/AdjectiveRegistration.fs
@@ -8,20 +8,20 @@ open Storage.ExerciseModels.AdjectiveComparative
 open Storage.ExerciseModels.AdjectivePlural
 open WikiParsing.Articles.AdjectiveArticle
 
-let private registerPlural = AdjectivePlural >> upsert "adjectiveplurals"
-let private registerComparative = AdjectiveComparative >> upsert "adjectivecomparatives"
+let private registerPlural id model = AdjectivePlural(id, model) |> upsert "adjectiveplurals"
+let private registerComparative id model = AdjectiveComparative(id, model) |> upsert "adjectivecomparatives"
 
 let registerAdjective article =
     let adjective = parseAdjectiveArticle article
 
     let pluralRegistration = 
         adjective.Declension 
-        |> Option.map (AdjectivePlural.Create adjective.CanonicalForm)
-        |> Option.map registerPlural
+        |> Option.map AdjectivePlural.Create
+        |> Option.map (registerPlural adjective.CanonicalForm)
 
     let comparativeRegistration = 
         adjective.Comparison 
-        |> Option.bind (AdjectiveComparative.Create adjective.CanonicalForm)
-        |> Option.map registerComparative
+        |> Option.bind AdjectiveComparative.Create
+        |> Option.map (registerComparative adjective.CanonicalForm)
 
     [ pluralRegistration; comparativeRegistration ] |> List.choose id

--- a/src/Scraper/WordRegistration/NounRegistration.fs
+++ b/src/Scraper/WordRegistration/NounRegistration.fs
@@ -6,14 +6,14 @@ open Storage.ExerciseModels.Noun
 open Common.WikiArticles
 open WikiParsing.Articles.NounArticle
 
-let registerNounDeclension = Noun >> upsert "nouns"
+let registerNounDeclension id model = Noun(id, model) |> upsert "nouns"
 
 let registerNoun article = 
     let noun = parseNounArticle article
 
     let nounDeclension = 
         noun
-        |> NounDeclension.Create noun.CanonicalForm
-        |> Option.map registerNounDeclension
+        |> NounDeclension.Create
+        |> Option.map (registerNounDeclension noun.CanonicalForm)
 
     [ nounDeclension ] |> List.choose id

--- a/src/Scraper/WordRegistration/VerbRegistration.fs
+++ b/src/Scraper/WordRegistration/VerbRegistration.fs
@@ -8,27 +8,27 @@ open Storage.ExerciseModels.VerbParticiple
 open Storage.ExerciseModels.VerbConjugation
 open WikiParsing.Articles.VerbArticle
 
-let registerVerbConjugation = VerbConjugation >> upsert "verbconjugation"
-let registerVerbImperative = VerbImperative >> upsert "verbimperatives"
-let registerVerbParticiple = VerbParticiple >> upsert "verbparticiples"
+let registerVerbConjugation id model = VerbConjugation(id, model) |> upsert "verbconjugation"
+let registerVerbImperative id model = VerbImperative(id, model) |> upsert "verbimperatives"
+let registerVerbParticiple id model = VerbParticiple(id, model) |> upsert "verbparticiples"
 
 let registerVerb verbArticle =
     let verb = parseVerbArticle verbArticle
 
     let conjugationRegistration = 
         verb
-        |> VerbConjugation.Create verb.CanonicalForm
-        |> Option.map registerVerbConjugation
+        |> VerbConjugation.Create
+        |> Option.map (registerVerbConjugation verb.CanonicalForm)
 
     let imperativeRegistration = 
         verb
-        |> VerbImperative.Create verb.CanonicalForm
-        |> Option.map registerVerbImperative
+        |> VerbImperative.Create
+        |> Option.map (registerVerbImperative verb.CanonicalForm)
 
     let participleRegistration = 
         verb
-        |> VerbParticiple.Create verb.CanonicalForm
-        |> Option.map registerVerbParticiple
+        |> VerbParticiple.Create
+        |> Option.map (registerVerbParticiple  verb.CanonicalForm)
 
     [ conjugationRegistration; imperativeRegistration; participleRegistration ] 
     |> List.choose id

--- a/src/Storage/Defaults.fs
+++ b/src/Storage/Defaults.fs
@@ -5,7 +5,6 @@ open Common.Exercises
 
 type Noun with 
     static member Default = {
-        Id = null
         Gender = None
         Patterns = null
         Declension = {
@@ -28,14 +27,12 @@ type Noun with
 
 type AdjectivePlural with 
     static member Default = {
-        Id = null
         Singular = null
         Plural = null
     }
 
 type AdjectiveComparative with 
     static member Default = {
-        Id = null
         Positive = null
         Comparatives = null
         IsRegular = false
@@ -43,7 +40,6 @@ type AdjectiveComparative with
 
 type VerbImperative with 
     static member Default = {
-        Id = null
         Indicative = null
         Imperatives = null
         Class = None
@@ -52,7 +48,6 @@ type VerbImperative with
 
 type VerbParticiple with 
     static member Default = {
-        Id = null
         Infinitive = null
         Participles = null
         Pattern = Verbs.Pattern.Common
@@ -61,7 +56,6 @@ type VerbParticiple with
 
 type VerbConjugation with 
     static member Default = {
-        Id = null
         Infinitive = null
         Pattern = Verbs.Pattern.Common
         Conjugation = {

--- a/src/Storage/ExerciseModels/AdjectiveComparative.fs
+++ b/src/Storage/ExerciseModels/AdjectiveComparative.fs
@@ -5,11 +5,11 @@ open Storage.Defaults
 open Storage.Storage
 open BaseEntity
 
-type AdjectiveComparative(model: Exercises.AdjectiveComparative) =
+type AdjectiveComparative(id, model: Exercises.AdjectiveComparative) =
 
-    inherit BaseEntity(model.Id)
+    inherit BaseEntity(id)
     
-    new() = AdjectiveComparative(Exercises.AdjectiveComparative.Default)
+    new() = AdjectiveComparative(null, Exercises.AdjectiveComparative.Default)
 
     [<SerializeObject>] member val Positive = model.Positive with get, set
     [<SerializeObject>] member val Comparatives = model.Comparatives with get, set

--- a/src/Storage/ExerciseModels/AdjectivePlural.fs
+++ b/src/Storage/ExerciseModels/AdjectivePlural.fs
@@ -5,11 +5,11 @@ open Storage.Defaults
 open Storage.Storage
 open BaseEntity
 
-type AdjectivePlural(model: Exercises.AdjectivePlural) =
-
-    inherit BaseEntity(model.Id)
+type AdjectivePlural (id, model: Exercises.AdjectivePlural) =
     
-    new() = AdjectivePlural(Exercises.AdjectivePlural.Default)
+    inherit BaseEntity(id)
+    
+    new() = AdjectivePlural(null, Exercises.AdjectivePlural.Default)
 
     [<SerializeObject>] member val Singular = model.Singular with get, set
     [<SerializeObject>] member val Plural = model.Plural with get, set

--- a/src/Storage/ExerciseModels/Noun.fs
+++ b/src/Storage/ExerciseModels/Noun.fs
@@ -5,11 +5,11 @@ open Storage.Defaults
 open Storage.Storage
 open BaseEntity
 
-type Noun(model: Exercises.Noun) = 
+type Noun(id, model: Exercises.Noun) = 
     
-    inherit BaseEntity(model.Id)
+    inherit BaseEntity(id)
 
-    new() = Noun(Exercises.Noun.Default)
+    new() = Noun(null, Exercises.Noun.Default)
 
     [<SerializeOption>] member val Gender = model.Gender with get, set
     [<SerializeObject>] member val Patterns = model.Patterns with get, set

--- a/src/Storage/ExerciseModels/VerbConjugation.fs
+++ b/src/Storage/ExerciseModels/VerbConjugation.fs
@@ -5,11 +5,11 @@ open Storage.Defaults
 open Storage.Storage
 open BaseEntity
 
-type VerbConjugation(model: Exercises.VerbConjugation) =
+type VerbConjugation(id, model: Exercises.VerbConjugation) =
 
-    inherit BaseEntity(model.Id)
+    inherit BaseEntity(id)
     
-    new() = VerbConjugation(Exercises.VerbConjugation.Default)
+    new() = VerbConjugation(null, Exercises.VerbConjugation.Default)
 
     [<SerializeObject>] member val Infinitive = model.Infinitive with get, set
     [<SerializeString>] member val Pattern = model.Pattern with get, set

--- a/src/Storage/ExerciseModels/VerbImperative.fs
+++ b/src/Storage/ExerciseModels/VerbImperative.fs
@@ -5,11 +5,11 @@ open Storage.Defaults
 open Storage.Storage
 open BaseEntity
 
-type VerbImperative(model: Exercises.VerbImperative) =
+type VerbImperative(id, model: Exercises.VerbImperative) =
 
-    inherit BaseEntity(model.Id)
+    inherit BaseEntity(id)
 
-    new() = VerbImperative(Exercises.VerbImperative.Default)
+    new() = VerbImperative(null, Exercises.VerbImperative.Default)
 
     [<SerializeObject>] member val Indicative = model.Indicative with get, set
     [<SerializeObject>] member val Imperatives = model.Imperatives with get, set

--- a/src/Storage/ExerciseModels/VerbParticiple.fs
+++ b/src/Storage/ExerciseModels/VerbParticiple.fs
@@ -5,11 +5,11 @@ open Storage.Defaults
 open Storage.Storage
 open BaseEntity
 
-type VerbParticiple(model: Exercises.VerbParticiple) =
+type VerbParticiple(id, model: Exercises.VerbParticiple) =
 
-    inherit BaseEntity(model.Id)
+    inherit BaseEntity(id)
 
-    new() = VerbParticiple(Exercises.VerbParticiple.Default)
+    new() = VerbParticiple(null, Exercises.VerbParticiple.Default)
 
     [<SerializeObject>] member val Infinitive = model.Infinitive with get, set
     [<SerializeObject>] member val Participles = model.Participles with get, set


### PR DESCRIPTION
Types in `Exercises` are meant to match what users see when doing exercises whereas Id is a storage concept. So Id is now generated during word registration, right before writing to database.