### PR TITLE
Minor cleanup in verb categories

### DIFF
--- a/src/Client/Pages/VerbImperatives.fs
+++ b/src/Client/Pages/VerbImperatives.fs
@@ -5,7 +5,7 @@ open Fable.PowerPack.Fetch
 open Thoth.Json
 open Fable.Helpers.React
 
-open Common.Verbs
+open Common.Conjugation
 open Client.Markup
 open Client.Styles
 open Client.Widgets

--- a/src/Client/Widgets/Class.fs
+++ b/src/Client/Widgets/Class.fs
@@ -5,8 +5,16 @@ open Fable.Helpers.React
 open Fable.Helpers.React.Props
 open Fable.Import.React
 
-open Common.Verbs
+open Common.Conjugation
 open Client
+
+let private parseVerbClass = function
+    | "E" -> E
+    | "NE" -> NE
+    | "JE" -> JE
+    | "Í" -> Í
+    | "Á" -> Á
+    | s -> invalidOp ("odd class: " + s)
 
 [<Literal>]
 let ClassUnset = ""
@@ -28,7 +36,7 @@ let update msg model =
 
 let view model dispatch =
     let handleChangeClass (event: FormEvent) =
-        let translate = function | ClassUnset -> None | x -> Some (VerbClass.parse x)
+        let translate = function | ClassUnset -> None | x -> Some (parseVerbClass x)
         dispatch (SetClass (translate !!event.target?value))
 
     let selectedValue = model.Class |> Option.map string |> Option.defaultValue "Any"

--- a/src/Common/Conjugation.fs
+++ b/src/Common/Conjugation.fs
@@ -25,6 +25,8 @@ type Conjugation = {
     ThirdPlural: seq<string>
 }
 
+type VerbClass = E | NE | JE | Í | Á
+
 type ConjugationPatternClassE =
    | Nést
    | Číst

--- a/src/Common/Exercises.fs
+++ b/src/Common/Exercises.fs
@@ -24,19 +24,19 @@ type AdjectiveComparative = {
 type VerbImperative = {
     Indicative: string
     Imperatives: seq<string>
-    Class: Verbs.VerbClass option
+    Class: VerbClass option
     Pattern: ConjugationPattern option
 }
 
 type VerbParticiple = {
     Infinitive: string
     Participles: seq<string>
-    Pattern: Verbs.Pattern
+    Pattern: Verbs.ParticiplePattern
     IsRegular: bool
 }
 
 type VerbConjugation = {
     Infinitive: string
-    Pattern: Verbs.Pattern
+    Pattern: Verbs.ParticiplePattern
     Conjugation: Conjugation.Conjugation
 }

--- a/src/Common/Verbs.fs
+++ b/src/Common/Verbs.fs
@@ -1,15 +1,6 @@
-﻿module Common.Verbs
+module Common.Verbs
 
-type VerbClass = E | NE | JE | Í | Á with 
-    static member parse = function
-        | "E" -> E
-        | "NE" -> NE
-        | "JE" -> JE
-        | "Í" -> Í
-        | "Á" -> Á
-        | s -> invalidOp ("odd class: " + s)
-
-type Pattern = 
+type ParticiplePattern = 
     | Minout
     | Tisknout
     | Common

--- a/src/Core/Verbs/ConjugationPatternDetector.fs
+++ b/src/Core/Verbs/ConjugationPatternDetector.fs
@@ -1,7 +1,6 @@
 ﻿module Core.Verbs.ConjugationPatternDetector
 
 open Common.StringHelper
-open Common.Verbs
 open Common.Conjugation
 open Core.Letters
 open Core.Stem

--- a/src/Core/Verbs/VerbClasses.fs
+++ b/src/Core/Verbs/VerbClasses.fs
@@ -1,7 +1,7 @@
 ﻿module Core.Verbs.VerbClasses
 
 open Common.StringHelper
-open Common.Verbs
+open Common.Conjugation
 
 let getClassByThirdPersonSingular = function
     | form when form |> ends "á"  -> Á

--- a/src/Storage/Defaults.fs
+++ b/src/Storage/Defaults.fs
@@ -50,14 +50,14 @@ type VerbParticiple with
     static member Default = {
         Infinitive = null
         Participles = null
-        Pattern = Verbs.Pattern.Common
+        Pattern = Verbs.ParticiplePattern.Common
         IsRegular = false
     }
 
 type VerbConjugation with 
     static member Default = {
         Infinitive = null
-        Pattern = Verbs.Pattern.Common
+        Pattern = Verbs.ParticiplePattern.Common
         Conjugation = {
             FirstSingular = null
             SecondSingular = null

--- a/tests/Core.Tests/VerbClassesTests.fs
+++ b/tests/Core.Tests/VerbClassesTests.fs
@@ -4,7 +4,7 @@ open System
 open Xunit
 
 open Core.Verbs.VerbClasses
-open Common.Verbs
+open Common.Conjugation
 
 [<Fact>]
 let ``Gets E class by third person singular``() =


### PR DESCRIPTION
Renamed `Pattern` to `ParticiplePattern` (because that's what it about as opposed to `ConjugationPattern`), moved `VerbClass` to `Conjugation` module (but some further cleanup in grammar categories will be probably needed).