### PR TITLE
Fixed pattern in the conjugation exercise (#688)

### DIFF
--- a/src/Client/Pages/VerbConjugation.fs
+++ b/src/Client/Pages/VerbConjugation.fs
@@ -8,28 +8,36 @@ open Fable.Helpers.React
 open Client.Markup
 open Client.Styles
 open Client.Widgets
+open Common.Conjugation
 
 type Model = {
     FilterBlock : FilterBlock.Types.Model
-    Pattern : Pattern.Model
-    Regularity : Regularity.Model
+    Class: Class.Model
+    Pattern: Pattern.Model
     Task : Task.Model
 }
 
 type Msg = 
     | FilterBlock of FilterBlock.Types.Msg
+    | Class of Class.Msg
     | Pattern of Pattern.Msg
-    | Regularity of Regularity.Msg
     | Task of Task.Msg
 
-let patterns = ["Minout"; "Tisknout"; "Common"]
+let patterns =
+    dict [ (E, ["nést"; "číst"; "péct"; "třít"; "brát"; "mazat"])
+           (NE, ["tisknout"; "minout"; "začít"])
+           (JE, ["krýt"; "kupovat"])
+           (Í, ["prosit"; "čistit"; "trpět"; "sázet"])
+           (Á, ["dělat"]) ]
 
-let getTask pattern regularity =
+let getPatterns ``class`` = patterns.[``class``]
+
+let getTask ``class`` pattern =
+    let classQuery = ``class`` |> Option.map (sprintf "class=%A")
     let patternQuery = pattern |> Option.map (sprintf "pattern=%s")
-    let regularityQuery = regularity |> Option.map string |> Option.map ((+) "isRegular=")
 
     let queryString =
-        [ patternQuery; regularityQuery ]
+        [ classQuery; patternQuery ]
         |> Seq.choose id
         |> String.concat "&"
     
@@ -42,13 +50,13 @@ let getTask pattern regularity =
 
 let init() =
     let filterBlock = FilterBlock.State.init()
-    let pattern = Pattern.init (Some patterns)
-    let regularity = Regularity.init()
+    let ``class`` = Class.init()
+    let pattern = Pattern.init None
     let task, cmd = Task.init "Verb Conjugation" (getTask None None)
 
     { FilterBlock = filterBlock
+      Class = ``class``
       Pattern = pattern
-      Regularity = regularity
       Task = task },
     Cmd.map Task cmd
 
@@ -60,18 +68,19 @@ let update msg model =
     | FilterBlock msg' ->
         let filterBlock, cmd = FilterBlock.State.update msg' model.FilterBlock
         { model with FilterBlock = filterBlock }, cmd
+    | Class msg' ->
+        let ``class`` = Class.update msg' model.Class
+        let patterns = ``class``.Class |> Option.map getPatterns
+        let pattern = Pattern.update (Pattern.SetPatterns patterns) model.Pattern
+        { model with 
+            Class = ``class`` 
+            Pattern = pattern
+        }, reloadTaskCmd
     | Pattern msg' ->
         let pattern = Pattern.update msg' model.Pattern
-        let regularity = Regularity.init()
-        { model with 
-            Pattern = pattern 
-            Regularity = regularity
-        }, reloadTaskCmd
-    | Regularity msg' ->
-        let regularity = Regularity.update msg' model.Regularity
-        { model with Regularity = regularity }, reloadTaskCmd
+        { model with Pattern = pattern }, reloadTaskCmd
     | Task msg' ->
-        let task, cmd = Task.update msg' model.Task (getTask model.Pattern.SelectedPattern model.Regularity.Regularity)
+        let task, cmd = Task.update msg' model.Task (getTask model.Class.Class model.Pattern.SelectedPattern)
         { model with Task = task }, Cmd.map Task cmd
 
 let view model dispatch =          
@@ -84,12 +93,12 @@ let view model dispatch =
                     [
                         div [ ]
                             [
-                                Pattern.view model.Pattern (Pattern >> dispatch)
+                                Class.view model.Class (Class >> dispatch)
                             ]
 
                         div [ ]
                             [
-                                Regularity.view model.Regularity (Regularity >> dispatch)
+                                Pattern.view model.Pattern (Pattern >> dispatch)
                             ]
                     ]
                     

--- a/src/Common/Exercises.fs
+++ b/src/Common/Exercises.fs
@@ -37,6 +37,7 @@ type VerbParticiple = {
 
 type VerbConjugation = {
     Infinitive: string
-    Pattern: Verbs.ParticiplePattern
+    Class: VerbClass option
+    Pattern: ConjugationPattern option
     Conjugation: Conjugation.Conjugation
 }

--- a/src/Scraper/ExerciseCreation/Verbs.fs
+++ b/src/Scraper/ExerciseCreation/Verbs.fs
@@ -21,14 +21,21 @@ let private getThirdPersonSingular (conjugation: VerbConjugation) =
     |> Seq.tryExactlyOne
 
 let private getParticiplePattern = ParticiplePatternDetector.getPattern
-let private getImperativePattern = ConjugationPatternDetector.getPattern
+let private getConjugationPattern = ConjugationPatternDetector.getPattern
 
 type VerbConjugation with 
     static member Create verb =
         verb.Conjugation |> Option.map (fun conjugation -> 
         {
             Infinitive = conjugation.Infinitive
-            Pattern = verb.CanonicalForm |> getParticiplePattern
+            Class = 
+                verb.Conjugation 
+                |> Option.bind getThirdPersonSingular
+                |> Option.map getClass
+            Pattern = 
+                verb.Conjugation
+                |> Option.bind getThirdPersonSingular
+                |> Option.bind (getConjugationPattern verb.CanonicalForm)
             Conjugation = conjugation.Conjugation
         })
 
@@ -45,7 +52,7 @@ type VerbImperative with
             Pattern = 
                 verb.Conjugation
                 |> Option.bind getThirdPersonSingular
-                |> Option.bind (getImperativePattern verb.CanonicalForm)
+                |> Option.bind (getConjugationPattern verb.CanonicalForm)
         })
 
 type VerbParticiple with 

--- a/src/Server/Tasks/Verb.fs
+++ b/src/Server/Tasks/Verb.fs
@@ -58,11 +58,14 @@ let getVerbParticiplesTask next (ctx: HttpContext) =
 
 let getVerbConjugationTask next (ctx: HttpContext) =
     task {
+        let classFromQuery = ctx.GetQueryStringValue "class"
+        let classFilter = getAzureFilter "Class" Int classFromQuery
+
         let patternFromQuery = ctx.GetQueryStringValue "pattern"
         let patternFilter = getAzureFilter "Pattern" String patternFromQuery
 
-        let filters =
-            [ patternFilter ] 
+        let filters = 
+            [ classFilter; patternFilter ]
             |> Seq.choose id
         
         let getConjugation (conjugation: VerbConjugation.VerbConjugation) = function

--- a/src/Storage/Defaults.fs
+++ b/src/Storage/Defaults.fs
@@ -57,7 +57,8 @@ type VerbParticiple with
 type VerbConjugation with 
     static member Default = {
         Infinitive = null
-        Pattern = Verbs.ParticiplePattern.Common
+        Class = None
+        Pattern = None
         Conjugation = {
             FirstSingular = null
             SecondSingular = null

--- a/src/Storage/ExerciseModels/VerbConjugation.fs
+++ b/src/Storage/ExerciseModels/VerbConjugation.fs
@@ -1,7 +1,9 @@
 module Storage.ExerciseModels.VerbConjugation
 
 open Common
+open Common.Conjugation
 open Storage.Defaults
+open Storage.Serialization
 open Storage.Storage
 open BaseEntity
 
@@ -12,8 +14,9 @@ type VerbConjugation(id, model: Exercises.VerbConjugation) =
     new() = VerbConjugation(null, Exercises.VerbConjugation.Default)
 
     [<SerializeObject>] member val Infinitive = model.Infinitive with get, set
-    [<SerializeString>] member val Pattern = model.Pattern with get, set
-    
+    [<SerializeOption>] member val Class = model.Class with get, set
+    [<SerializeOption>] member val Pattern = model.Pattern |> Option.map ConjugationPattern.toString with get, set
+
     [<SerializeObject>] member val FirstSingular = model.Conjugation.FirstSingular with get, set
     [<SerializeObject>] member val SecondSingular = model.Conjugation.SecondSingular with get, set
     [<SerializeObject>] member val ThirdSingular = model.Conjugation.ThirdSingular with get, set


### PR DESCRIPTION
After all the refactoring and cleanup with verb patterns, I realized that we are using wrong patterns for the conjugation exercise. We should use class and conjugation patterns there, instead of very specific participle patterns that work only for making participle form.