### PR TITLE
Optimized declension extraction (#699)

### DIFF
--- a/src/WikiParsing/Articles/NounArticle.fs
+++ b/src/WikiParsing/Articles/NounArticle.fs
@@ -1,7 +1,5 @@
 ﻿module WikiParsing.Articles.NounArticle
 
-open FSharp.Data
-
 open WikiParsing.WikiString
 open WikiParsing.NounWikiDeclension
 open Article
@@ -11,10 +9,6 @@ open Common.GrammarCategories
 open Common.Utils
 open Common.GenderTranslations
 open Common.WikiArticles
-
-type EditableArticleOneDeclension = HtmlProvider<"https://cs.wiktionary.org/wiki/panda">
-type EditableArticleTwoDeclensions = HtmlProvider<"https://cs.wiktionary.org/wiki/čtvrt">
-type LockedArticle = HtmlProvider<"https://cs.wiktionary.org/wiki/debil">
 
 let getNumberOfDeclensions (NounArticle article) =
     article

--- a/src/WikiParsing/Articles/NounArticle.fs
+++ b/src/WikiParsing/Articles/NounArticle.fs
@@ -3,6 +3,7 @@
 open FSharp.Data
 
 open WikiParsing.WikiString
+open WikiParsing.NounWikiDeclension
 open Article
 open Common
 open Common.Declension
@@ -15,15 +16,6 @@ type EditableArticleOneDeclension = HtmlProvider<"https://cs.wiktionary.org/wiki
 type EditableArticleTwoDeclensions = HtmlProvider<"https://cs.wiktionary.org/wiki/čtvrt">
 type LockedArticle = HtmlProvider<"https://cs.wiktionary.org/wiki/debil">
 
-let caseColumns = 
-    dict [ Case.Nominative, 0
-           Case.Genitive, 1
-           Case.Dative, 2
-           Case.Accusative, 3
-           Case.Vocative, 4
-           Case.Locative, 5
-           Case.Instrumental, 6 ]
-
 let getNumberOfDeclensions (NounArticle article) =
     article
     |> matches [
@@ -31,40 +23,6 @@ let getNumberOfDeclensions (NounArticle article) =
         Starts "skloňování"
     ]
     |> Seq.length
-
-let getEditable (case: Case) number article =
-    let numberOfDeclensions = getNumberOfDeclensions article
-    let (NounArticle {Title = word; Text = text}) = article
-
-    let caseColumn = caseColumns.[case]
-    match numberOfDeclensions with
-    | 1 ->
-        let data = EditableArticleOneDeclension.Parse text
-        match number with
-        | Singular ->
-            [ data.Tables.``Skloňování[editovat]``.Rows.[caseColumn].singulár ]
-        | Plural -> 
-            [ data.Tables.``Skloňování[editovat]``.Rows.[caseColumn].plurál ]
-    | 2 ->
-        let data = EditableArticleTwoDeclensions.Parse text
-        match number with
-        | Singular ->
-            [ data.Tables.``Skloňování (1)[editovat]``.Rows.[caseColumn].singulár 
-              data.Tables.``Skloňování (2)[editovat]``.Rows.[caseColumn].singulár ]
-        | Plural -> 
-            [ data.Tables.``Skloňování (1)[editovat]``.Rows.[caseColumn].plurál 
-              data.Tables.``Skloňování (2)[editovat]``.Rows.[caseColumn].plurál ]
-    | _ ->
-        invalidOp ("Odd word: " + word)
-
-let getLocked (case: Case) number (NounArticle { Text = text }) =
-    let data = LockedArticle.Parse text
-    let caseColumn = caseColumns.[case]
-    match number with
-    | Singular ->
-        [ data.Tables.Skloňování.Rows.[caseColumn].singulár ]
-    | Plural -> 
-        [ data.Tables.Skloňování.Rows.[caseColumn].plurál ]
 
 let getDeclinability (NounArticle article) =
     let hasIndeclinabilityMarkInNounSection = 
@@ -86,42 +44,64 @@ let getDeclinability (NounArticle article) =
     then Indeclinable
     else Declinable
 
-let getDeclensionWiki (case: Case) number nounArticle =
+let private getDeclensionWiki nounArticle = 
     let (NounArticle article) = nounArticle
     let word = article.Title
+    let numberOfDeclensions = nounArticle |> getNumberOfDeclensions
 
     match word with
-    | _ when getDeclinability nounArticle = Indeclinable ->
-        [ word ]
-    | _ when article |> isEditable ->
-        getEditable case number nounArticle
+    | _ when article |> isEditable && numberOfDeclensions = 1 ->
+        [ getEditable1Declension nounArticle ]
+    | _ when article |> isEditable && numberOfDeclensions = 2 ->
+          getEditable2Declensions nounArticle
     | _ when article |> isLocked ->
-        getLocked case number nounArticle
-    | word -> 
+        [ getLocked nounArticle ]
+    | _ -> 
         invalidOp ("Odd word: " + word)
 
-let private getPartialDeclension case number = 
-    getDeclensionWiki case number 
-    >> Seq.collect getForms
-    >> Seq.distinct
+let private getDeclensionForDeclinable article = 
+    let declensions = getDeclensionWiki article
+    let getForms getCase = Seq.map getCase >> Seq.collect getForms >> Seq.distinct
 
-let getDeclension article = 
     {
-        SingularNominative = article |> getPartialDeclension Case.Nominative Number.Singular
-        SingularGenitive = article |> getPartialDeclension Case.Genitive Number.Singular
-        SingularDative = article |> getPartialDeclension Case.Dative Number.Singular
-        SingularAccusative = article |> getPartialDeclension Case.Accusative Number.Singular
-        SingularVocative = article |> getPartialDeclension Case.Vocative Number.Singular
-        SingularLocative = article |> getPartialDeclension Case.Locative Number.Singular
-        SingularInstrumental = article |> getPartialDeclension Case.Instrumental Number.Singular
-        PluralNominative = article |> getPartialDeclension Case.Nominative Number.Plural
-        PluralGenitive = article |> getPartialDeclension Case.Genitive Number.Plural
-        PluralDative = article |> getPartialDeclension Case.Dative Number.Plural
-        PluralAccusative = article |> getPartialDeclension Case.Accusative Number.Plural
-        PluralVocative = article |> getPartialDeclension Case.Vocative Number.Plural
-        PluralLocative = article |> getPartialDeclension Case.Locative Number.Plural
-        PluralInstrumental = article |> getPartialDeclension Case.Instrumental Number.Plural
+        SingularNominative =   declensions |> getForms (fun d -> d.SingularNominative)
+        SingularGenitive =     declensions |> getForms (fun d -> d.SingularGenitive)
+        SingularDative =       declensions |> getForms (fun d -> d.SingularDative)
+        SingularAccusative =   declensions |> getForms (fun d -> d.SingularAccusative)
+        SingularVocative =     declensions |> getForms (fun d -> d.SingularVocative)
+        SingularLocative =     declensions |> getForms (fun d -> d.SingularLocative)
+        SingularInstrumental = declensions |> getForms (fun d -> d.SingularInstrumental)
+        PluralNominative =     declensions |> getForms (fun d -> d.PluralNominative)
+        PluralGenitive =       declensions |> getForms (fun d -> d.PluralGenitive)
+        PluralDative =         declensions |> getForms (fun d -> d.PluralDative)
+        PluralAccusative =     declensions |> getForms (fun d -> d.PluralAccusative)
+        PluralVocative =       declensions |> getForms (fun d -> d.PluralVocative)
+        PluralLocative =       declensions |> getForms (fun d -> d.PluralLocative)
+        PluralInstrumental =   declensions |> getForms (fun d -> d.PluralInstrumental)
     }
+
+let private getDeclensionForIndeclinable (NounArticle { Title = word }) = 
+    {
+        SingularNominative =   seq { word }
+        SingularGenitive =     seq { word }
+        SingularDative =       seq { word }
+        SingularVocative =     seq { word }
+        SingularAccusative =   seq { word }
+        SingularLocative =     seq { word }
+        SingularInstrumental = seq { word }
+        PluralNominative =     seq { word }
+        PluralGenitive =       seq { word }
+        PluralDative =         seq { word }
+        PluralAccusative =     seq { word }
+        PluralVocative =       seq { word }
+        PluralLocative =       seq { word }
+        PluralInstrumental =   seq { word }
+    }
+
+let getDeclension article =
+    match article |> getDeclinability with
+    | Declinability.Declinable -> getDeclensionForDeclinable article
+    | Declinability.Indeclinable -> getDeclensionForIndeclinable article
 
 let getGender (NounArticle article) =
     article

--- a/src/WikiParsing/NounWikiDeclension.fs
+++ b/src/WikiParsing/NounWikiDeclension.fs
@@ -1,0 +1,102 @@
+﻿module WikiParsing.NounWikiDeclension
+
+open FSharp.Data
+
+open Common.WikiArticles
+
+type private EditableArticle1Declension = HtmlProvider<"https://cs.wiktionary.org/wiki/panda">
+type private EditableArticle2Declensions = HtmlProvider<"https://cs.wiktionary.org/wiki/čtvrt">
+type private LockedArticle = HtmlProvider<"https://cs.wiktionary.org/wiki/debil">
+
+type WikiDeclension = 
+    {
+        SingularNominative: string
+        SingularGenitive: string
+        SingularDative: string
+        SingularAccusative: string
+        SingularVocative: string
+        SingularLocative: string
+        SingularInstrumental: string
+        PluralNominative: string
+        PluralGenitive: string
+        PluralDative: string
+        PluralAccusative: string
+        PluralVocative: string
+        PluralLocative: string
+        PluralInstrumental: string
+    }
+
+let getEditable1Declension (NounArticle { Text = text }) =
+    let data = EditableArticle1Declension.Parse text
+    {
+        SingularNominative =   data.Tables.``Skloňování[editovat]``.Rows.[0].singulár
+        SingularGenitive =     data.Tables.``Skloňování[editovat]``.Rows.[1].singulár
+        SingularDative =       data.Tables.``Skloňování[editovat]``.Rows.[2].singulár
+        SingularVocative =     data.Tables.``Skloňování[editovat]``.Rows.[4].singulár
+        SingularAccusative =   data.Tables.``Skloňování[editovat]``.Rows.[3].singulár
+        SingularLocative =     data.Tables.``Skloňování[editovat]``.Rows.[5].singulár
+        SingularInstrumental = data.Tables.``Skloňování[editovat]``.Rows.[6].singulár
+        PluralNominative =     data.Tables.``Skloňování[editovat]``.Rows.[0].plurál  
+        PluralGenitive =       data.Tables.``Skloňování[editovat]``.Rows.[1].plurál  
+        PluralDative =         data.Tables.``Skloňování[editovat]``.Rows.[2].plurál  
+        PluralAccusative =     data.Tables.``Skloňování[editovat]``.Rows.[3].plurál  
+        PluralVocative =       data.Tables.``Skloňování[editovat]``.Rows.[4].plurál  
+        PluralLocative =       data.Tables.``Skloňování[editovat]``.Rows.[5].plurál  
+        PluralInstrumental =   data.Tables.``Skloňování[editovat]``.Rows.[6].plurál  
+    }
+
+let getEditable2Declensions (NounArticle { Text = text }) =
+    let data = EditableArticle2Declensions.Parse text
+    [
+        {
+            SingularNominative =   data.Tables.``Skloňování (1)[editovat]``.Rows.[0].singulár
+            SingularGenitive =     data.Tables.``Skloňování (1)[editovat]``.Rows.[1].singulár
+            SingularDative =       data.Tables.``Skloňování (1)[editovat]``.Rows.[2].singulár
+            SingularVocative =     data.Tables.``Skloňování (1)[editovat]``.Rows.[4].singulár
+            SingularAccusative =   data.Tables.``Skloňování (1)[editovat]``.Rows.[3].singulár
+            SingularLocative =     data.Tables.``Skloňování (1)[editovat]``.Rows.[5].singulár
+            SingularInstrumental = data.Tables.``Skloňování (1)[editovat]``.Rows.[6].singulár
+            PluralNominative =     data.Tables.``Skloňování (1)[editovat]``.Rows.[0].plurál  
+            PluralGenitive =       data.Tables.``Skloňování (1)[editovat]``.Rows.[1].plurál  
+            PluralDative =         data.Tables.``Skloňování (1)[editovat]``.Rows.[2].plurál  
+            PluralAccusative =     data.Tables.``Skloňování (1)[editovat]``.Rows.[3].plurál  
+            PluralVocative =       data.Tables.``Skloňování (1)[editovat]``.Rows.[4].plurál  
+            PluralLocative =       data.Tables.``Skloňování (1)[editovat]``.Rows.[5].plurál  
+            PluralInstrumental =   data.Tables.``Skloňování (1)[editovat]``.Rows.[6].plurál  
+        }
+        {
+            SingularNominative =   data.Tables.``Skloňování (2)[editovat]``.Rows.[0].singulár
+            SingularGenitive =     data.Tables.``Skloňování (2)[editovat]``.Rows.[1].singulár
+            SingularDative =       data.Tables.``Skloňování (2)[editovat]``.Rows.[2].singulár
+            SingularVocative =     data.Tables.``Skloňování (2)[editovat]``.Rows.[4].singulár
+            SingularAccusative =   data.Tables.``Skloňování (2)[editovat]``.Rows.[3].singulár
+            SingularLocative =     data.Tables.``Skloňování (2)[editovat]``.Rows.[5].singulár
+            SingularInstrumental = data.Tables.``Skloňování (2)[editovat]``.Rows.[6].singulár
+            PluralNominative =     data.Tables.``Skloňování (2)[editovat]``.Rows.[0].plurál  
+            PluralGenitive =       data.Tables.``Skloňování (2)[editovat]``.Rows.[1].plurál  
+            PluralDative =         data.Tables.``Skloňování (2)[editovat]``.Rows.[2].plurál  
+            PluralAccusative =     data.Tables.``Skloňování (2)[editovat]``.Rows.[3].plurál  
+            PluralVocative =       data.Tables.``Skloňování (2)[editovat]``.Rows.[4].plurál  
+            PluralLocative =       data.Tables.``Skloňování (2)[editovat]``.Rows.[5].plurál  
+            PluralInstrumental =   data.Tables.``Skloňování (2)[editovat]``.Rows.[6].plurál  
+        }
+    ]
+
+let getLocked (NounArticle { Text = text }) =
+    let data = LockedArticle.Parse text
+    {
+        SingularNominative =   data.Tables.``Skloňování``.Rows.[0].singulár
+        SingularGenitive =     data.Tables.``Skloňování``.Rows.[1].singulár
+        SingularDative =       data.Tables.``Skloňování``.Rows.[2].singulár
+        SingularVocative =     data.Tables.``Skloňování``.Rows.[4].singulár
+        SingularAccusative =   data.Tables.``Skloňování``.Rows.[3].singulár
+        SingularLocative =     data.Tables.``Skloňování``.Rows.[5].singulár
+        SingularInstrumental = data.Tables.``Skloňování``.Rows.[6].singulár
+        PluralNominative =     data.Tables.``Skloňování``.Rows.[0].plurál  
+        PluralGenitive =       data.Tables.``Skloňování``.Rows.[1].plurál  
+        PluralDative =         data.Tables.``Skloňování``.Rows.[2].plurál  
+        PluralAccusative =     data.Tables.``Skloňování``.Rows.[3].plurál  
+        PluralVocative =       data.Tables.``Skloňování``.Rows.[4].plurál  
+        PluralLocative =       data.Tables.``Skloňování``.Rows.[5].plurál  
+        PluralInstrumental =   data.Tables.``Skloňování``.Rows.[6].plurál  
+    }

--- a/src/WikiParsing/WikiParsing.fsproj
+++ b/src/WikiParsing/WikiParsing.fsproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Compile Include="Html.fs" />
     <Compile Include="WikiString.fs" />
+    <Compile Include="NounWikiDeclension.fs" />
     <Compile Include="Articles\Article.fs" />
     <Compile Include="Articles\NounArticle.fs" />
     <Compile Include="Articles\AdjectiveArticle.fs" />

--- a/tests/WikiParsing.Tests/NounArticleTests.fs
+++ b/tests/WikiParsing.Tests/NounArticleTests.fs
@@ -20,25 +20,18 @@ let ``Gets number of declensions``() =
     |> equals 1
 
 [<Fact>]
-let ``Gets declension wiki - indeclinable``() = 
-    "dada"
-    |> getArticle
-    |> getDeclensionWiki Case.Nominative Number.Plural
-    |> equals ["dada"]
-
-[<Fact>]
-let ``Gets declension wiki - editable article``() = 
+let ``Gets declension - editable article``() = 
     "panda"
-    |> getArticle
-    |> getDeclensionWiki Case.Nominative Number.Plural
-    |> equals ["pandy"]
+    |> getDeclension
+    |> fun declension -> declension.PluralNominative
+    |> seqEquals ["pandy"]
 
 [<Fact>]
-let ``Gets wiki plural wiki - locked article``() = 
+let ``Gets declension - locked article``() = 
     "debil"
-    |> getArticle
-    |> getDeclensionWiki Case.Nominative Number.Plural
-    |> equals ["debilové"]
+    |> getDeclension
+    |> fun declnesion -> declnesion.PluralNominative
+    |> seqEquals ["debilové"]
 
 [<Fact>]
 let ``Gets declension - indeclinable``() =
@@ -67,13 +60,6 @@ let ``Gets declension - multiple declensions``() =
     |> getDeclension
     |> fun declension -> declension.PluralNominative
     |> seqEquals ["čtvrtě"; "čtvrti"]
-
-[<Fact>]
-let ``Gets singulars - multiple options``() =
-    "temeno"
-    |> getDeclension
-    |> fun declension -> declension.SingularNominative
-    |> seqEquals ["temeno"; "témě"]
     
 [<Theory>]
 [<InlineData "dada">]


### PR DESCRIPTION
The idea is to collect all the cases in one go, instead of initializing type providers for each case. Thanks to this, tests now run approximately 4-5x faster (mostly because of those for noun pattern detection).

I moved all type provider related work to a separate module, `NounWikiDeclension`. It works on its own type, `WikiDeclension`, which is basically raw strings from wiki. Then in `NounArticle` we convert that to our domain type `Declension`, which contains parsed and distinct forms, possibly from multiple tables. 