### PR TITLE
Minor model adjustment

### DIFF
--- a/src/Common/Exercises.fs
+++ b/src/Common/Exercises.fs
@@ -5,6 +5,7 @@ open Conjugation
 open GrammarCategories
 
 type Noun = {
+    CanonicalForm: string
     Gender: Gender option
     Patterns: seq<DeclensionPattern>
     Declension: Declension

--- a/src/Scraper/ExerciseCreation/Nouns.fs
+++ b/src/Scraper/ExerciseCreation/Nouns.fs
@@ -13,6 +13,7 @@ type NounDeclension with
     static member Create (noun: NounDeclension) = 
         if noun.Declension.IsSome 
         then Some {
+                CanonicalForm = noun.CanonicalForm
                 Gender = noun.Gender
                 Patterns = noun |> getPatterns
                 Declension = noun.Declension.Value

--- a/src/Server/Tasks/Noun.fs
+++ b/src/Server/Tasks/Noun.fs
@@ -54,11 +54,7 @@ let getNounDeclensionTask next (ctx: HttpContext) =
         
         let! noun = tryGetRandomWithFilters<Noun> "nouns" azureFilters postFilters
         let getTask (noun: Noun) = 
-            let canonicalForm = 
-                if noun.SingularNominative |> Seq.any
-                then noun.SingularNominative |> Seq.random
-                else noun.PluralNominative |> Seq.random
-
+            let canonicalForm = noun.CanonicalForm
             let answers = noun |> getDeclensionProp (number, case)
             let declension = case.ToString() + " " + number.ToString()
             let word = sprintf "(%s) %s" declension canonicalForm

--- a/src/Storage/Defaults.fs
+++ b/src/Storage/Defaults.fs
@@ -5,6 +5,7 @@ open Common.Exercises
 
 type Noun with 
     static member Default = {
+        CanonicalForm = null
         Gender = None
         Patterns = Seq.empty
         Declension = {

--- a/src/Storage/ExerciseModels/Noun.fs
+++ b/src/Storage/ExerciseModels/Noun.fs
@@ -13,6 +13,7 @@ type Noun(id, model: Exercises.Noun) =
 
     new() = Noun(null, Exercises.Noun.Default)
 
+    [<SerializeObject>] member val CanonicalForm = model.CanonicalForm with get, set
     [<SerializeOption>] member val Gender = model.Gender with get, set
     [<SerializeObject>] member val Patterns = model.Patterns |> Seq.map DeclensionPattern.toString with get, set
 


### PR DESCRIPTION
This is related to the fact that when parsing Wiktionary we already know the canonical form of the noun (that's the title of the article) so we better propagate it rather than "forget" it and figure it out again on the upper level. 

That will be also similar to "infinitive" for conjugation, it is just that declension does not have such a nice term for the canonical form (e.g. [lemma](https://en.wikipedia.org/wiki/Lemma_(morphology)), which seams less clear to me).