### PR TITLE
Fixed extra requests during exercises (#709)

### DIFF
--- a/src/Client/Client.fsproj
+++ b/src/Client/Client.fsproj
@@ -34,6 +34,7 @@
 		<Compile Include="Widgets\Class.fs" />
 		<Compile Include="Widgets\Regularity.fs" />
 		<Compile Include="Widgets\Task.fs" />
+		<Compile Include="Utils.fs" />
 		<Compile Include="Pages\NounDeclension.fs" />
 		<Compile Include="Pages\NounAccusatives.fs" />
 		<Compile Include="Pages\VerbParticiples.fs" />

--- a/src/Client/Pages/AdjectiveComparatives.fs
+++ b/src/Client/Pages/AdjectiveComparatives.fs
@@ -2,12 +2,11 @@
 
 open Elmish
 open Fable.React
-open Thoth.Json
-open Thoth.Fetch
 
 open Client
 open Client.Views
 open Client.Widgets
+open Client.Utils
 
 type Model = {
     FilterBlock : FilterBlock.Types.Model
@@ -26,7 +25,7 @@ let getTask regularity =
         | Some r -> "/api/adjectives/comparatives?isRegular=" + r.ToString()
         | None   -> "/api/adjectives/comparatives"
 
-    Fetch.fetchAs(url, Decode.Auto.generateDecoder<Task.Task option>())
+    buildFetchTask url
 
 let init() =
     let filterBlock = FilterBlock.State.init()

--- a/src/Client/Pages/AdjectivePlurals.fs
+++ b/src/Client/Pages/AdjectivePlurals.fs
@@ -1,11 +1,10 @@
 ﻿module Client.Pages.AdjectivePlurals
 
 open Elmish
-open Thoth.Fetch
-open Thoth.Json
 open Fable.React
 
 open Client
+open Client.Utils
 open Client.Widgets
 
 type Model = {
@@ -17,7 +16,7 @@ type Msg =
 
 let getTask() =
     let url = "/api/adjectives/plurals"
-    Fetch.fetchAs(url, Decode.Auto.generateDecoder<Task.Task option>())
+    buildFetchTask url
 
 let init() =
     let task, cmd = Task.init "Adjective Plurals" (getTask())

--- a/src/Client/Pages/NounAccusatives.fs
+++ b/src/Client/Pages/NounAccusatives.fs
@@ -1,12 +1,11 @@
 ﻿module Client.Pages.NounAccusatives
 
 open Elmish
-open Thoth.Fetch
-open Thoth.Json
 open Fable.React
 
 open Common.GrammarCategories
 open Client
+open Client.Utils
 open Client.Widgets
 
 type Model = {
@@ -44,7 +43,7 @@ let getTask gender pattern =
         then "/api/nouns/accusatives" 
         else sprintf "/api/nouns/accusatives?%s" queryString
 
-    Fetch.fetchAs(url, Decode.Auto.generateDecoder<Task.Task option>())
+    buildFetchTask url
 
 let init () =
     let filterBlock = FilterBlock.State.init()

--- a/src/Client/Pages/NounDeclension.fs
+++ b/src/Client/Pages/NounDeclension.fs
@@ -1,13 +1,12 @@
 ﻿module Client.Pages.NounDeclension
 
 open Elmish
-open Thoth.Fetch
-open Thoth.Json
 open Fable.React
 
 open Common.GrammarCategories
 open Client.Markup
 open Client.Styles
+open Client.Utils
 open Client.Widgets
 
 type Model = {
@@ -51,7 +50,7 @@ let getTask gender pattern number case =
         then "/api/nouns/declension" 
         else sprintf "/api/nouns/declension?%s" queryString
 
-    Fetch.fetchAs(url, Decode.Auto.generateDecoder<Task.Task option>())
+    buildFetchTask url
 
 let init () =
     let filterBlock = FilterBlock.State.init()

--- a/src/Client/Pages/NounPlurals.fs
+++ b/src/Client/Pages/NounPlurals.fs
@@ -1,13 +1,12 @@
 ﻿module Client.Pages.NounPlurals
 
 open Elmish
-open Thoth.Fetch
-open Thoth.Json
 open Fable.React
 
 open Common.GrammarCategories
 open Client.Markup
 open Client.Styles
+open Client.Utils
 open Client.Widgets
 
 type Model = {
@@ -45,7 +44,7 @@ let getTask gender pattern =
         then "/api/nouns/plurals" 
         else sprintf "/api/nouns/plurals?%s" queryString
 
-    Fetch.fetchAs(url, Decode.Auto.generateDecoder<Task.Task option>())
+    buildFetchTask url
 
 let init () =
     let filterBlock = FilterBlock.State.init()

--- a/src/Client/Pages/VerbConjugation.fs
+++ b/src/Client/Pages/VerbConjugation.fs
@@ -1,12 +1,11 @@
 ﻿module Client.Pages.VerbConjugation
 
 open Elmish
-open Thoth.Fetch
-open Thoth.Json
 open Fable.React
 
 open Client.Markup
 open Client.Styles
+open Client.Utils
 open Client.Widgets
 open Common.Conjugation
 
@@ -46,7 +45,7 @@ let getTask ``class`` pattern =
         then "/api/verbs/conjugation" 
         else sprintf "/api/verbs/conjugation?%s" queryString
 
-    Fetch.fetchAs(url, Decode.Auto.generateDecoder<Task.Task option>())
+    buildFetchTask url
 
 let init() =
     let filterBlock = FilterBlock.State.init()

--- a/src/Client/Pages/VerbImperatives.fs
+++ b/src/Client/Pages/VerbImperatives.fs
@@ -1,13 +1,12 @@
 ﻿module Client.Pages.VerbImperatives
 
 open Elmish
-open Thoth.Fetch
-open Thoth.Json
 open Fable.React
 
 open Common.Conjugation
 open Client.Markup
 open Client.Styles
+open Client.Utils
 open Client.Widgets
 
 type Model = { 
@@ -46,7 +45,7 @@ let getTask ``class`` pattern =
         then "/api/verbs/imperatives" 
         else sprintf "/api/verbs/imperatives?%s" queryString
 
-    Fetch.fetchAs(url, Decode.Auto.generateDecoder<Task.Task option>())
+    buildFetchTask url
 
 let init() =
     let filterBlock = FilterBlock.State.init()

--- a/src/Client/Pages/VerbParticiples.fs
+++ b/src/Client/Pages/VerbParticiples.fs
@@ -1,14 +1,13 @@
 ﻿module Client.Pages.VerbParticiples
 
 open Elmish
-open Thoth.Fetch
-open Thoth.Json
 open Fable.React
 
 open Client
 open Client.Views
 open Client.Markup
 open Client.Styles
+open Client.Utils
 open Client.Widgets
 
 type Model = {
@@ -40,7 +39,7 @@ let getTask pattern regularity =
         then "/api/verbs/participles" 
         else sprintf "/api/verbs/participles?%s" queryString
 
-    Fetch.fetchAs(url, Decode.Auto.generateDecoder<Task.Task option>())
+    buildFetchTask url
 
 let init() =
     let filterBlock = FilterBlock.State.init()

--- a/src/Client/Utils.fs
+++ b/src/Client/Utils.fs
@@ -1,0 +1,11 @@
+﻿module Client.Utils
+
+open Thoth
+open Thoth.Fetch
+open Thoth.Json
+
+open Client.Widgets
+
+let buildFetchTask url = 
+    let decoder = Decode.Auto.generateDecoder<Task.Task option>()
+    fun _ -> Fetch.fetchAs(url, decoder)

--- a/src/Client/Widgets/Task.fs
+++ b/src/Client/Widgets/Task.fs
@@ -71,7 +71,7 @@ let log taskName task answer result =
     Logger.log message
 
 let loadTaskCmd getTask =
-    Cmd.OfPromise.either (fun _ -> getTask) [] FetchedTask FetchError
+    Cmd.OfPromise.either getTask [] FetchedTask FetchError
 
 let getStateTask s = 
     match s with 


### PR DESCRIPTION
When updating Fable, I accidentally changed the way promises work in the app, and the code for loading tasks started to execute for every event (including any key press). This fixes that behavior.

Basically we are not passing around `fun _ -> Fetch.fetchAs(url, decoder)` instead of `Fetch.fetchAs(url, decoder)`.