### PR TITLE
Parsing all cases for adjective declension (#717)

### DIFF
--- a/src/WikiParsing/AdjectiveWikiParsing.fs
+++ b/src/WikiParsing/AdjectiveWikiParsing.fs
@@ -1,0 +1,101 @@
+﻿module WikiParsing.AdjectiveWikiParsing
+
+open FSharp.Data
+
+open Common.WikiArticles
+open WikiParsing.ConcreteArticles
+
+type private WikiAdjectiveNový = HtmlProvider<"https://cs.wiktionary.org/wiki/nový">
+type private WikiAdjectiveStarý = HtmlProvider<"https://cs.wiktionary.org/wiki/starý">
+type private WikiAdjectiveVrchní = HtmlProvider<"https://cs.wiktionary.org/wiki/vrchní">
+
+type WikiDeclension = 
+    {
+        SingularNominative: string
+        SingularGenitive: string
+        SingularDative: string
+        SingularAccusative: string
+        SingularVocative: string
+        SingularLocative: string
+        SingularInstrumental: string
+        PluralNominative: string
+        PluralGenitive: string
+        PluralDative: string
+        PluralAccusative: string
+        PluralVocative: string
+        PluralLocative: string
+        PluralInstrumental: string
+    }
+
+type WikiComparison =
+    {
+        Positive: string
+        Comparative: string
+        Superlative: string
+    }
+
+let get1Declension (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) =
+    let data = WikiAdjectiveNový.Parse text
+    {
+        SingularNominative =   data.Tables.``Skloňování[editovat]``.Rows.[0].``singulár - mužský životný``
+        SingularGenitive =     data.Tables.``Skloňování[editovat]``.Rows.[1].``singulár - mužský životný`` 
+        SingularDative =       data.Tables.``Skloňování[editovat]``.Rows.[2].``singulár - mužský životný`` 
+        SingularVocative =     data.Tables.``Skloňování[editovat]``.Rows.[4].``singulár - mužský životný`` 
+        SingularAccusative =   data.Tables.``Skloňování[editovat]``.Rows.[3].``singulár - mužský životný`` 
+        SingularLocative =     data.Tables.``Skloňování[editovat]``.Rows.[5].``singulár - mužský životný`` 
+        SingularInstrumental = data.Tables.``Skloňování[editovat]``.Rows.[6].``singulár - mužský životný`` 
+        PluralNominative =     data.Tables.``Skloňování[editovat]``.Rows.[0].``plurál - mužský životný``  
+        PluralGenitive =       data.Tables.``Skloňování[editovat]``.Rows.[1].``plurál - mužský životný``  
+        PluralDative =         data.Tables.``Skloňování[editovat]``.Rows.[2].``plurál - mužský životný``  
+        PluralAccusative =     data.Tables.``Skloňování[editovat]``.Rows.[3].``plurál - mužský životný``  
+        PluralVocative =       data.Tables.``Skloňování[editovat]``.Rows.[4].``plurál - mužský životný``  
+        PluralLocative =       data.Tables.``Skloňování[editovat]``.Rows.[5].``plurál - mužský životný``  
+        PluralInstrumental =   data.Tables.``Skloňování[editovat]``.Rows.[6].``plurál - mužský životný``  
+    }
+
+let get2Declension (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) =
+    let data = WikiAdjectiveStarý.Parse text
+    {
+        SingularNominative =   data.Tables.``Skloňování[editovat]2``.Rows.[0].``singulár - mužský životný``
+        SingularGenitive =     data.Tables.``Skloňování[editovat]2``.Rows.[1].``singulár - mužský životný`` 
+        SingularDative =       data.Tables.``Skloňování[editovat]2``.Rows.[2].``singulár - mužský životný`` 
+        SingularVocative =     data.Tables.``Skloňování[editovat]2``.Rows.[4].``singulár - mužský životný`` 
+        SingularAccusative =   data.Tables.``Skloňování[editovat]2``.Rows.[3].``singulár - mužský životný`` 
+        SingularLocative =     data.Tables.``Skloňování[editovat]2``.Rows.[5].``singulár - mužský životný`` 
+        SingularInstrumental = data.Tables.``Skloňování[editovat]2``.Rows.[6].``singulár - mužský životný`` 
+        PluralNominative =     data.Tables.``Skloňování[editovat]2``.Rows.[0].``plurál - mužský životný``  
+        PluralGenitive =       data.Tables.``Skloňování[editovat]2``.Rows.[1].``plurál - mužský životný``  
+        PluralDative =         data.Tables.``Skloňování[editovat]2``.Rows.[2].``plurál - mužský životný``  
+        PluralAccusative =     data.Tables.``Skloňování[editovat]2``.Rows.[3].``plurál - mužský životný``  
+        PluralVocative =       data.Tables.``Skloňování[editovat]2``.Rows.[4].``plurál - mužský životný``  
+        PluralLocative =       data.Tables.``Skloňování[editovat]2``.Rows.[5].``plurál - mužský životný``  
+        PluralInstrumental =   data.Tables.``Skloňování[editovat]2``.Rows.[6].``plurál - mužský životný``  
+    }
+
+let get3Declension (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) =
+    let data = WikiAdjectiveVrchní.Parse text
+    {
+        SingularNominative =   data.Tables.``Skloňování[editovat]3``.Rows.[0].``singulár - mužský životný``
+        SingularGenitive =     data.Tables.``Skloňování[editovat]3``.Rows.[1].``singulár - mužský životný`` 
+        SingularDative =       data.Tables.``Skloňování[editovat]3``.Rows.[2].``singulár - mužský životný`` 
+        SingularVocative =     data.Tables.``Skloňování[editovat]3``.Rows.[4].``singulár - mužský životný`` 
+        SingularAccusative =   data.Tables.``Skloňování[editovat]3``.Rows.[3].``singulár - mužský životný`` 
+        SingularLocative =     data.Tables.``Skloňování[editovat]3``.Rows.[5].``singulár - mužský životný`` 
+        SingularInstrumental = data.Tables.``Skloňování[editovat]3``.Rows.[6].``singulár - mužský životný`` 
+        PluralNominative =     data.Tables.``Skloňování[editovat]3``.Rows.[0].``plurál - mužský životný``  
+        PluralGenitive =       data.Tables.``Skloňování[editovat]3``.Rows.[1].``plurál - mužský životný``  
+        PluralDative =         data.Tables.``Skloňování[editovat]3``.Rows.[2].``plurál - mužský životný``  
+        PluralAccusative =     data.Tables.``Skloňování[editovat]3``.Rows.[3].``plurál - mužský životný``  
+        PluralVocative =       data.Tables.``Skloňování[editovat]3``.Rows.[4].``plurál - mužský životný``  
+        PluralLocative =       data.Tables.``Skloňování[editovat]3``.Rows.[5].``plurál - mužský životný``  
+        PluralInstrumental =   data.Tables.``Skloňování[editovat]3``.Rows.[6].``plurál - mužský životný``  
+    }
+
+let getComparison (AdjectiveArticleWithComparative (AdjectiveArticle { Text = text })) = 
+    let data = WikiAdjectiveNový.Parse text
+    {
+        Positive = data.Tables.``Stupňování[editovat]``.Rows.[0].tvar
+        Comparative = data.Tables.``Stupňování[editovat]``.Rows.[1].tvar
+        Superlative = data.Tables.``Stupňování[editovat]``.Rows.[2].tvar
+    }
+

--- a/src/WikiParsing/AdjectiveWikiParsing.fs
+++ b/src/WikiParsing/AdjectiveWikiParsing.fs
@@ -34,68 +34,72 @@ type WikiComparison =
         Superlative: string
     }
 
-let get1Declension (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) =
+let getFirstDeclension (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) =
     let data = WikiAdjectiveNový.Parse text
+    let declensionTable = data.Tables.``Skloňování[editovat]``
     {
-        SingularNominative =   data.Tables.``Skloňování[editovat]``.Rows.[0].``singulár - mužský životný``
-        SingularGenitive =     data.Tables.``Skloňování[editovat]``.Rows.[1].``singulár - mužský životný`` 
-        SingularDative =       data.Tables.``Skloňování[editovat]``.Rows.[2].``singulár - mužský životný`` 
-        SingularVocative =     data.Tables.``Skloňování[editovat]``.Rows.[4].``singulár - mužský životný`` 
-        SingularAccusative =   data.Tables.``Skloňování[editovat]``.Rows.[3].``singulár - mužský životný`` 
-        SingularLocative =     data.Tables.``Skloňování[editovat]``.Rows.[5].``singulár - mužský životný`` 
-        SingularInstrumental = data.Tables.``Skloňování[editovat]``.Rows.[6].``singulár - mužský životný`` 
-        PluralNominative =     data.Tables.``Skloňování[editovat]``.Rows.[0].``plurál - mužský životný``  
-        PluralGenitive =       data.Tables.``Skloňování[editovat]``.Rows.[1].``plurál - mužský životný``  
-        PluralDative =         data.Tables.``Skloňování[editovat]``.Rows.[2].``plurál - mužský životný``  
-        PluralAccusative =     data.Tables.``Skloňování[editovat]``.Rows.[3].``plurál - mužský životný``  
-        PluralVocative =       data.Tables.``Skloňování[editovat]``.Rows.[4].``plurál - mužský životný``  
-        PluralLocative =       data.Tables.``Skloňování[editovat]``.Rows.[5].``plurál - mužský životný``  
-        PluralInstrumental =   data.Tables.``Skloňování[editovat]``.Rows.[6].``plurál - mužský životný``  
+        SingularNominative =   declensionTable.Rows.[0].``singulár - mužský životný``
+        SingularGenitive =     declensionTable.Rows.[1].``singulár - mužský životný`` 
+        SingularDative =       declensionTable.Rows.[2].``singulár - mužský životný`` 
+        SingularVocative =     declensionTable.Rows.[4].``singulár - mužský životný`` 
+        SingularAccusative =   declensionTable.Rows.[3].``singulár - mužský životný`` 
+        SingularLocative =     declensionTable.Rows.[5].``singulár - mužský životný`` 
+        SingularInstrumental = declensionTable.Rows.[6].``singulár - mužský životný`` 
+        PluralNominative =     declensionTable.Rows.[0].``plurál - mužský životný``  
+        PluralGenitive =       declensionTable.Rows.[1].``plurál - mužský životný``  
+        PluralDative =         declensionTable.Rows.[2].``plurál - mužský životný``  
+        PluralAccusative =     declensionTable.Rows.[3].``plurál - mužský životný``  
+        PluralVocative =       declensionTable.Rows.[4].``plurál - mužský životný``  
+        PluralLocative =       declensionTable.Rows.[5].``plurál - mužský životný``  
+        PluralInstrumental =   declensionTable.Rows.[6].``plurál - mužský životný``  
     }
 
-let get2Declension (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) =
+let getSecondDeclension (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) =
     let data = WikiAdjectiveStarý.Parse text
+    let declensionTable = data.Tables.``Skloňování[editovat]2``
     {
-        SingularNominative =   data.Tables.``Skloňování[editovat]2``.Rows.[0].``singulár - mužský životný``
-        SingularGenitive =     data.Tables.``Skloňování[editovat]2``.Rows.[1].``singulár - mužský životný`` 
-        SingularDative =       data.Tables.``Skloňování[editovat]2``.Rows.[2].``singulár - mužský životný`` 
-        SingularVocative =     data.Tables.``Skloňování[editovat]2``.Rows.[4].``singulár - mužský životný`` 
-        SingularAccusative =   data.Tables.``Skloňování[editovat]2``.Rows.[3].``singulár - mužský životný`` 
-        SingularLocative =     data.Tables.``Skloňování[editovat]2``.Rows.[5].``singulár - mužský životný`` 
-        SingularInstrumental = data.Tables.``Skloňování[editovat]2``.Rows.[6].``singulár - mužský životný`` 
-        PluralNominative =     data.Tables.``Skloňování[editovat]2``.Rows.[0].``plurál - mužský životný``  
-        PluralGenitive =       data.Tables.``Skloňování[editovat]2``.Rows.[1].``plurál - mužský životný``  
-        PluralDative =         data.Tables.``Skloňování[editovat]2``.Rows.[2].``plurál - mužský životný``  
-        PluralAccusative =     data.Tables.``Skloňování[editovat]2``.Rows.[3].``plurál - mužský životný``  
-        PluralVocative =       data.Tables.``Skloňování[editovat]2``.Rows.[4].``plurál - mužský životný``  
-        PluralLocative =       data.Tables.``Skloňování[editovat]2``.Rows.[5].``plurál - mužský životný``  
-        PluralInstrumental =   data.Tables.``Skloňování[editovat]2``.Rows.[6].``plurál - mužský životný``  
+        SingularNominative =   declensionTable.Rows.[0].``singulár - mužský životný``
+        SingularGenitive =     declensionTable.Rows.[1].``singulár - mužský životný`` 
+        SingularDative =       declensionTable.Rows.[2].``singulár - mužský životný`` 
+        SingularVocative =     declensionTable.Rows.[4].``singulár - mužský životný`` 
+        SingularAccusative =   declensionTable.Rows.[3].``singulár - mužský životný`` 
+        SingularLocative =     declensionTable.Rows.[5].``singulár - mužský životný`` 
+        SingularInstrumental = declensionTable.Rows.[6].``singulár - mužský životný`` 
+        PluralNominative =     declensionTable.Rows.[0].``plurál - mužský životný``  
+        PluralGenitive =       declensionTable.Rows.[1].``plurál - mužský životný``  
+        PluralDative =         declensionTable.Rows.[2].``plurál - mužský životný``  
+        PluralAccusative =     declensionTable.Rows.[3].``plurál - mužský životný``  
+        PluralVocative =       declensionTable.Rows.[4].``plurál - mužský životný``  
+        PluralLocative =       declensionTable.Rows.[5].``plurál - mužský životný``  
+        PluralInstrumental =   declensionTable.Rows.[6].``plurál - mužský životný``  
     }
 
-let get3Declension (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) =
+let getThirdDeclension (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) =
     let data = WikiAdjectiveVrchní.Parse text
+    let declensionTable = data.Tables.``Skloňování[editovat]3``
     {
-        SingularNominative =   data.Tables.``Skloňování[editovat]3``.Rows.[0].``singulár - mužský životný``
-        SingularGenitive =     data.Tables.``Skloňování[editovat]3``.Rows.[1].``singulár - mužský životný`` 
-        SingularDative =       data.Tables.``Skloňování[editovat]3``.Rows.[2].``singulár - mužský životný`` 
-        SingularVocative =     data.Tables.``Skloňování[editovat]3``.Rows.[4].``singulár - mužský životný`` 
-        SingularAccusative =   data.Tables.``Skloňování[editovat]3``.Rows.[3].``singulár - mužský životný`` 
-        SingularLocative =     data.Tables.``Skloňování[editovat]3``.Rows.[5].``singulár - mužský životný`` 
-        SingularInstrumental = data.Tables.``Skloňování[editovat]3``.Rows.[6].``singulár - mužský životný`` 
-        PluralNominative =     data.Tables.``Skloňování[editovat]3``.Rows.[0].``plurál - mužský životný``  
-        PluralGenitive =       data.Tables.``Skloňování[editovat]3``.Rows.[1].``plurál - mužský životný``  
-        PluralDative =         data.Tables.``Skloňování[editovat]3``.Rows.[2].``plurál - mužský životný``  
-        PluralAccusative =     data.Tables.``Skloňování[editovat]3``.Rows.[3].``plurál - mužský životný``  
-        PluralVocative =       data.Tables.``Skloňování[editovat]3``.Rows.[4].``plurál - mužský životný``  
-        PluralLocative =       data.Tables.``Skloňování[editovat]3``.Rows.[5].``plurál - mužský životný``  
-        PluralInstrumental =   data.Tables.``Skloňování[editovat]3``.Rows.[6].``plurál - mužský životný``  
+        SingularNominative =   declensionTable.Rows.[0].``singulár - mužský životný``
+        SingularGenitive =     declensionTable.Rows.[1].``singulár - mužský životný`` 
+        SingularDative =       declensionTable.Rows.[2].``singulár - mužský životný`` 
+        SingularVocative =     declensionTable.Rows.[4].``singulár - mužský životný`` 
+        SingularAccusative =   declensionTable.Rows.[3].``singulár - mužský životný`` 
+        SingularLocative =     declensionTable.Rows.[5].``singulár - mužský životný`` 
+        SingularInstrumental = declensionTable.Rows.[6].``singulár - mužský životný`` 
+        PluralNominative =     declensionTable.Rows.[0].``plurál - mužský životný``  
+        PluralGenitive =       declensionTable.Rows.[1].``plurál - mužský životný``  
+        PluralDative =         declensionTable.Rows.[2].``plurál - mužský životný``  
+        PluralAccusative =     declensionTable.Rows.[3].``plurál - mužský životný``  
+        PluralVocative =       declensionTable.Rows.[4].``plurál - mužský životný``  
+        PluralLocative =       declensionTable.Rows.[5].``plurál - mužský životný``  
+        PluralInstrumental =   declensionTable.Rows.[6].``plurál - mužský životný``  
     }
 
 let getComparison (AdjectiveArticleWithComparative (AdjectiveArticle { Text = text })) = 
     let data = WikiAdjectiveNový.Parse text
+    let comparisonTable = data.Tables.``Stupňování[editovat]``
     {
-        Positive = data.Tables.``Stupňování[editovat]``.Rows.[0].tvar
-        Comparative = data.Tables.``Stupňování[editovat]``.Rows.[1].tvar
-        Superlative = data.Tables.``Stupňování[editovat]``.Rows.[2].tvar
+        Positive =    comparisonTable.Rows.[0].tvar
+        Comparative = comparisonTable.Rows.[1].tvar
+        Superlative = comparisonTable.Rows.[2].tvar
     }
 

--- a/src/WikiParsing/Articles/AdjectiveArticle.fs
+++ b/src/WikiParsing/Articles/AdjectiveArticle.fs
@@ -30,9 +30,9 @@ let private getWikiDeclension article =
     let numberOfDeclensions = article |> getNumberOfDeclensions
 
     match numberOfDeclensions with
-    | 1 -> get1Declension article
-    | 2 -> get2Declension article
-    | 3 -> get3Declension article
+    | 1 -> getFirstDeclension article
+    | 2 -> getSecondDeclension article
+    | 3 -> getThirdDeclension article
     | _ -> invalidOp "Invalid article"
 
 let getDeclension article =

--- a/src/WikiParsing/Articles/AdjectiveArticle.fs
+++ b/src/WikiParsing/Articles/AdjectiveArticle.fs
@@ -1,42 +1,10 @@
 ﻿module WikiParsing.Articles.AdjectiveArticle
 
-open FSharp.Data
-
+open Common.WikiArticles
+open WikiParsing.AdjectiveWikiParsing
 open WikiParsing.WikiString
 open WikiParsing.Articles.Article
-open Common.WikiArticles
-
-type WikiAdjective = HtmlProvider<"https://cs.wiktionary.org/wiki/nový">
-type WikiAdjectiveNový = HtmlProvider<"https://cs.wiktionary.org/wiki/nový">
-type WikiAdjectiveStarý = HtmlProvider<"https://cs.wiktionary.org/wiki/starý">
-type WikiAdjectiveVrchní = HtmlProvider<"https://cs.wiktionary.org/wiki/vrchní">
-
-type AdjectiveArticleWithPlural = AdjectiveArticleWithPlural of AdjectiveArticle
-type AdjectiveArticleWithComparative = AdjectiveArticleWithComparative of AdjectiveArticle
-
-let getAdjectiveProvider (AdjectiveArticle { Text = text }) =
-    text
-    |> WikiAdjective.Parse
-
-let getPluralDobrý (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) = 
-    text
-    |> WikiAdjectiveNový.Parse
-    |> fun data -> data.Tables.``Skloňování[editovat]``.Rows.[0].``plurál - mužský životný``
-
-let getPluralStarý (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) = 
-    text
-    |> WikiAdjectiveStarý.Parse
-    |> fun data -> data.Tables.``Skloňování[editovat]2``.Rows.[0].``plurál - mužský životný``
-
-let getPluralVrchní (AdjectiveArticleWithPlural (AdjectiveArticle { Text = text })) = 
-    text
-    |> WikiAdjectiveVrchní.Parse
-    |> fun data -> data.Tables.``Skloňování[editovat]3``.Rows.[0].``plurál - mužský životný``
-
-let pluralDeclensionsMap =
-    dict [ (1, getPluralDobrý)
-           (2, getPluralStarý)
-           (3, getPluralVrchní) ]
+open WikiParsing.ConcreteArticles
 
 let getNumberOfDeclensions (AdjectiveArticleWithPlural (AdjectiveArticle article)) = 
     article
@@ -58,16 +26,28 @@ let private hasRequiredInfoComparative (AdjectiveArticle article) =
         Is "stupňování"
     ]
 
-let getPlural article =
-    article
-    |> getNumberOfDeclensions
-    |> fun n -> pluralDeclensionsMap.[n] article
+let private getWikiDeclension article = 
+    let numberOfDeclensions = article |> getNumberOfDeclensions
 
-let getComparatives (AdjectiveArticleWithComparative article) =
-    article
-    |> getAdjectiveProvider
-    |> fun data -> data.Tables.``Stupňování[editovat]``.Rows.[1].tvar
-    |> getForms
+    match numberOfDeclensions with
+    | 1 -> get1Declension article
+    | 2 -> get2Declension article
+    | 3 -> get3Declension article
+    | _ -> invalidOp "Invalid article"
+
+let getDeclension article =
+    let declension = getWikiDeclension article
+    {
+        Singular = declension.SingularNominative
+        Plural = declension.PluralNominative
+    }
+
+let getComparison article =
+    let comparison = getComparison article
+    {
+        Positive = comparison.Positive |> getForm
+        Comparatives = comparison.Comparative |> getForms
+    }
 
 let parseAdjectivePlural article = 
     if article |> hasRequiredInfoPlural
@@ -86,15 +66,9 @@ let parseAdjectiveArticle article =
         Declension =
             article
             |> parseAdjectivePlural
-            |> Option.map (fun article -> { 
-                Singular = title
-                Plural = article |> getPlural 
-            })
+            |> Option.map getDeclension
         Comparison = 
             article
             |> parseAdjectiveComparative
-            |> Option.map (fun article -> {
-                Positive = title
-                Comparatives = article |> getComparatives
-            })
+            |> Option.map getComparison
     }

--- a/src/WikiParsing/ConcreteArticles.fs
+++ b/src/WikiParsing/ConcreteArticles.fs
@@ -1,0 +1,6 @@
+﻿module WikiParsing.ConcreteArticles
+
+open Common.WikiArticles
+
+type AdjectiveArticleWithComparative = AdjectiveArticleWithComparative of AdjectiveArticle
+type AdjectiveArticleWithPlural = AdjectiveArticleWithPlural of AdjectiveArticle

--- a/src/WikiParsing/WikiParsing.fsproj
+++ b/src/WikiParsing/WikiParsing.fsproj
@@ -14,8 +14,10 @@
     <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ConcreteArticles.fs" />
     <Compile Include="Html.fs" />
     <Compile Include="WikiString.fs" />
+    <Compile Include="AdjectiveWikiParsing.fs" />
     <Compile Include="NounWikiDeclension.fs" />
     <Compile Include="Articles\Article.fs" />
     <Compile Include="Articles\NounArticle.fs" />

--- a/tests/WikiParsing.Tests/AdjectiveArticleTests.fs
+++ b/tests/WikiParsing.Tests/AdjectiveArticleTests.fs
@@ -2,8 +2,9 @@
 
 open Xunit
 
-open WikiParsing.Articles.AdjectiveArticle
 open Common.WikiArticles
+open WikiParsing.Articles.AdjectiveArticle
+open WikiParsing.ConcreteArticles
 
 let getArticle = 
     getArticle
@@ -14,7 +15,8 @@ let ``Gets plural - when not nominalized``() =
     "laskavý"
     |> getArticle 
     |> AdjectiveArticleWithPlural
-    |> getPlural
+    |> getDeclension
+    |> fun d -> d.Plural
     |> equals "laskaví"
 
 [<Fact>]
@@ -22,7 +24,8 @@ let ``Gets plural - when nominalized once``() =
     "vrátný"
     |> getArticle 
     |> AdjectiveArticleWithPlural
-    |> getPlural
+    |> getDeclension
+    |> fun d -> d.Plural
     |> equals "vrátní"
 
 [<Fact>]
@@ -30,7 +33,8 @@ let ``Gets plural - when nominalized twice``() =
     "duchovní"
     |> getArticle 
     |> AdjectiveArticleWithPlural
-    |> getPlural
+    |> getDeclension
+    |> fun d -> d.Plural
     |> equals "duchovní"
 
 [<Fact>]
@@ -38,7 +42,8 @@ let ``Gets comparatives``() =
     "dobrý"
     |> getArticle 
     |> AdjectiveArticleWithComparative
-    |> getComparatives
+    |> getComparison
+    |> fun d -> d.Comparatives
     |> seqEquals [ "lepší" ]
 
 [<Fact>]


### PR DESCRIPTION
I want to create a new exercise for general adjective declension and for that we need to take all the cases from wiki.

I implemented it in similar fashion to what we have with nouns: created a separate module (`AdjectiveWikiParsing`) doing just parsing stuff and integrated it into `AdjectiveArticle`.