### PR TITLE
Fixed processing of multiple participle forms (#727)

### DIFF
--- a/src/WikiParsing/Articles/VerbArticle.fs
+++ b/src/WikiParsing/Articles/VerbArticle.fs
@@ -36,7 +36,7 @@ let getParticipleByTableIndex article participleTableIndex =
         | 2 -> getParticipleWhenImperativePresent article
         | _ -> invalidOp "Invalid article"
 
-    wikiParticiple.SingularMasculineAnimate |> getForm
+    wikiParticiple.SingularMasculineAnimate
 
 let getWikiParticiples verbParticipleArticle =
     let (VerbArticleWithParticiple (VerbArticle article)) = verbParticipleArticle


### PR DESCRIPTION
Copypaste issue - calling `WikiString` framework too early.