### PR TITLE
Refactoring: several code alignments around verbs

### DIFF
--- a/src/Common/GrammarCategories/Verbs.fs
+++ b/src/Common/GrammarCategories/Verbs.fs
@@ -8,15 +8,6 @@ type Pronoun =
     | SecondPlural 
     | ThirdPlural
 
-type Conjugation = {
-    FirstSingular: seq<string>
-    SecondSingular: seq<string>
-    ThirdSingular: seq<string>
-    FirstPlural: seq<string>
-    SecondPlural: seq<string>
-    ThirdPlural: seq<string>
-}
-
 type VerbClass = E | NE | JE | Í | Á
 
 type ConjugationPatternClassE =
@@ -56,6 +47,16 @@ type ParticiplePattern =
     | Minout
     | Tisknout
     | Common
+
+type Conjugation = {
+    Infinitive: string
+    FirstSingular: seq<string>
+    SecondSingular: seq<string>
+    ThirdSingular: seq<string>
+    FirstPlural: seq<string>
+    SecondPlural: seq<string>
+    ThirdPlural: seq<string>
+}
 
 type Imperative = {
     Indicative: string

--- a/src/Common/WikiArticles.fs
+++ b/src/Common/WikiArticles.fs
@@ -24,14 +24,9 @@ type Adjective = {
     Comparison: Adjectives.Comparison option
 }
 
-type VerbConjugation = {
-    Infinitive: string
-    Conjugation: Verbs.Conjugation
-}
-
 type Verb = {
     CanonicalForm: string
-    Conjugation: VerbConjugation option
+    Conjugation: Verbs.Conjugation option
     Imperative: Verbs.Imperative option
     Participle: Verbs.Participle option
 }

--- a/src/Scraper/ExerciseCreation/Verbs.fs
+++ b/src/Scraper/ExerciseCreation/Verbs.fs
@@ -17,8 +17,8 @@ let private getClass =
     removeReflexive
     >> getClassByThirdPersonSingular
 
-let private getThirdPersonSingular (conjugation: VerbConjugation) = 
-    conjugation.Conjugation.ThirdSingular
+let private getThirdPersonSingular conjugation = 
+    conjugation.ThirdSingular
     |> Seq.tryExactlyOne
 
 let private getParticiplePattern = ParticiplePatternDetector.getPattern
@@ -37,7 +37,7 @@ type VerbConjugation with
                 verb.Conjugation
                 |> Option.bind getThirdPersonSingular
                 |> Option.bind (getConjugationPattern verb.CanonicalForm)
-            Conjugation = conjugation.Conjugation
+            Conjugation = conjugation
         })
 
 type VerbImperative with 

--- a/src/Storage/Defaults.fs
+++ b/src/Storage/Defaults.fs
@@ -77,6 +77,7 @@ type VerbConjugation with
         Class = None
         Pattern = None
         Conjugation = {
+            Infinitive = null
             FirstSingular = null
             SecondSingular = null
             ThirdSingular = null

--- a/tests/WikiParsing.Tests/VerbArticleTests.fs
+++ b/tests/WikiParsing.Tests/VerbArticleTests.fs
@@ -12,35 +12,43 @@ let getArticle =
 
 [<Fact>]
 let ``Gets imperatives - single option``() =
-    "milovat"
-    |> getArticle 
-    |> VerbArticleWithImperative
-    |> getImperatives
-    |> seqEquals ["miluj"]
+    let imperative = 
+        "milovat"
+        |> getArticle 
+        |> VerbArticleWithImperative
+        |> getImperative
+
+    imperative.Imperatives |> seqEquals ["miluj"]
 
 [<Fact>]
 let ``Gets imperatives - multiple options``() =
-    "orat"
-    |> getArticle
-    |> VerbArticleWithImperative
-    |> getImperatives
-    |> seqEquals ["oř"; "orej"]
+    let imperative = 
+        "orat"
+        |> getArticle
+        |> VerbArticleWithImperative
+        |> getImperative
+
+    imperative.Imperatives |> seqEquals ["oř"; "orej"]
 
 [<Fact>]
 let ``Gets participle from the second table``() = 
-    "uvidět"
-    |> getArticle
-    |> VerbArticleWithParticiple
-    |> getParticiples
-    |> seqEquals ["uviděl"]
+    let participle =
+        "uvidět"
+        |> getArticle
+        |> VerbArticleWithParticiple
+        |> getParticiple
+
+    participle.Participles |> seqEquals ["uviděl"]
 
 [<Fact>]
 let ``Gets participle from the third table``() = 
-    "myslet"
-    |> getArticle
-    |> VerbArticleWithParticiple
-    |> getParticiples
-    |> seqEquals ["myslel"]
+    let participle = 
+        "myslet"
+        |> getArticle
+        |> VerbArticleWithParticiple
+        |> getParticiple
+
+    participle.Participles |> seqEquals ["myslel"]
 
 [<Fact>]
 let ``Gets all conjugations``() =


### PR DESCRIPTION
That's basically for `WikiArticles` types to look uniform.