### PR TITLE
More idiomatic server responses

### DIFF
--- a/src/Client/Utils.fs
+++ b/src/Client/Utils.fs
@@ -7,5 +7,5 @@ open Thoth.Json
 open Client.Widgets
 
 let buildFetchTask url = 
-    let decoder = Decode.Auto.generateDecoder<Task.Task option>()
+    let decoder = Decode.Auto.generateDecoder<Task.Task>()
     fun _ -> Fetch.fetchAs(url, decoder)

--- a/src/Client/Widgets/Task.fs
+++ b/src/Client/Widgets/Task.fs
@@ -61,7 +61,7 @@ type Msg =
     | CheckAnswer
     | NextTask
     | ChangeSymbolCase
-    | FetchedTask of Task option
+    | FetchedTask of Task
     | FetchError of exn
 
 type LeftButtonState = Show | Next
@@ -112,8 +112,8 @@ let update msg model getTask =
     | FetchedTask task -> 
         { model with 
             State = InputProvided ({ 
-                        Word = task |> Option.map (fun t -> t.Word) |> Option.defaultValue DefaultWord; 
-                        Answers = task |> Option.map (fun t -> t.Answers) |> Option.defaultValue DefaultAnswers
+                        Word = task.Word 
+                        Answers = task.Answers
                     }, NoInput)
         }, Cmd.none
     | FetchError _ ->

--- a/src/Server/Tasks/Adjective.fs
+++ b/src/Server/Tasks/Adjective.fs
@@ -76,6 +76,6 @@ let getAdjectiveComparativesTask next (ctx : HttpContext) =
     
             let task = adjective |> getTask
             return! Successful.OK task next ctx
-        | _ ->
+        | None ->
             return! RequestErrors.NOT_FOUND "Not Found" next ctx
     }

--- a/src/Server/Tasks/Utils.fs
+++ b/src/Server/Tasks/Utils.fs
@@ -8,8 +8,8 @@ let getPostFilter filterCondition = function
     | Ok parameterValue -> Some (filterCondition parameterValue)
     | Error _ -> None
 
-
-[<AllowNullLiteral>]
-type Task(word, answers) = 
-    member this.Word: string = word
-    member this.Answers: seq<string> = answers
+[<CLIMutable>]
+type Task = {
+    Word: string
+    Answers: string[]
+}

--- a/src/Server/Tasks/Verb.fs
+++ b/src/Server/Tasks/Verb.fs
@@ -24,14 +24,17 @@ let getVerbImperativesTask next (ctx : HttpContext) =
             |> Seq.choose id
             
         let! verb = tryGetRandom<VerbImperative.VerbImperative> "verbimperatives" filters
+        match verb with
+        | Some verb ->
+            let getTask (verb: VerbImperative.VerbImperative) = 
+                let indicative = verb.Indicative
+                let imperatives = verb.Imperatives
+                { Word = indicative; Answers = imperatives |> Seq.toArray }
 
-        let getTask (verb: VerbImperative.VerbImperative) = 
-            let indicative = verb.Indicative
-            let imperatives = verb.Imperatives
-            Task(indicative, imperatives)
-
-        let task = verb |> Option.map getTask |> Option.toObj 
-        return! Successful.OK task next ctx
+            let task = verb |> getTask
+            return! Successful.OK task next ctx
+        | None ->
+            return! RequestErrors.NOT_FOUND "Not Found" next ctx
     }
 
 let getVerbParticiplesTask next (ctx: HttpContext) =
@@ -47,14 +50,17 @@ let getVerbParticiplesTask next (ctx: HttpContext) =
             |> Seq.choose id
         
         let! verb = tryGetRandom<VerbParticiple.VerbParticiple> "verbparticiples" filters
+        match verb with
+        | Some verb ->
+            let getTask (verb: VerbParticiple.VerbParticiple) = 
+                let infinitive = verb.Infinitive
+                let participles = verb.Participles
+                { Word = infinitive; Answers = participles |> Seq.toArray }
 
-        let getTask (verb: VerbParticiple.VerbParticiple) = 
-            let infinitive = verb.Infinitive
-            let participles = verb.Participles
-            Task(infinitive, participles)
-
-        let task = verb |> Option.map getTask |> Option.toObj 
-        return! Successful.OK task next ctx
+            let task = verb |> getTask
+            return! Successful.OK task next ctx
+        | None ->
+            return! RequestErrors.NOT_FOUND "Not Found" next ctx
     }
 
 let getVerbConjugationTask next (ctx: HttpContext) =
@@ -78,14 +84,18 @@ let getVerbConjugationTask next (ctx: HttpContext) =
             | ThirdPlural    -> conjugation.ThirdPlural
 
         let! verb = tryGetRandom<VerbConjugation.VerbConjugation> "verbconjugation" filters
-        let getTask (verb: VerbConjugation.VerbConjugation) =
-            let pronoun = getRandomUnion<Pronoun>
-            let infinitive = verb.Infinitive
-            let answers = getConjugation verb pronoun
-            let pn = pronounToString pronoun
-            let word = sprintf "(%s) %s _____" infinitive pn 
-            Task(word, answers)
+        match verb with
+        | Some verb ->
+            let getTask (verb: VerbConjugation.VerbConjugation) =
+                let pronoun = getRandomUnion<Pronoun>
+                let infinitive = verb.Infinitive
+                let answers = getConjugation verb pronoun
+                let pn = pronounToString pronoun
+                let word = sprintf "(%s) %s _____" infinitive pn 
+                { Word = word; Answers = answers |> Seq.toArray }
 
-        let task = verb |> Option.map getTask |> Option.toObj 
-        return! Successful.OK task next ctx
+            let task = verb |> getTask
+            return! Successful.OK task next ctx
+        | None ->
+            return! RequestErrors.NOT_FOUND "Not Found" next ctx
     }


### PR DESCRIPTION
A few improvements on client-server interaction:
1) Different responses in case of found and not found, seems like [idiomatic way](https://github.com/search?l=F%23&q=return%21+RequestErrors.NOT_FOUND&type=Code) in F#
2) More native type for task (record instead of class)