### PR TITLE
centered display + mobile filter fix

### DIFF
--- a/src/Client/Pages/NounDeclension.fs
+++ b/src/Client/Pages/NounDeclension.fs
@@ -109,25 +109,10 @@ let view model dispatch =
             [
                 FilterBlock.View.root model.FilterBlock (FilterBlock >> dispatch) 
                     [
-                        div [  ]
-                            [
-                                Gender.view model.Gender (Gender >> dispatch)
-                            ]
-
-                        div [ ]
-                            [
-                                Pattern.view model.Pattern (Pattern >> dispatch)
-                            ]
-
-                        div [ ]
-                            [
-                                Number.view model.Number (Number >> dispatch)
-                            ]
-
-                        div [ ]
-                            [
-                                Case.view model.Case (Case >> dispatch)
-                            ]
+                        Gender.view model.Gender (Gender >> dispatch)
+                        Pattern.view model.Pattern (Pattern >> dispatch)
+                        Number.view model.Number (Number >> dispatch)
+                        Case.view model.Case (Case >> dispatch)
                     ]
 
                 Task.view model.Task (Task >> dispatch)

--- a/src/Client/Widgets/Case.fs
+++ b/src/Client/Widgets/Case.fs
@@ -34,7 +34,7 @@ let view model dispatch =
 
     let selectedValue = model.Case |> Option.map string |> Option.defaultValue "Any"
 
-    div [ClassName "case-filter"] 
+    div [ClassName "filter case-filter"] 
         [
             div [ ClassName "case-filter-label" ] 
                 [

--- a/src/Client/Widgets/Class.fs
+++ b/src/Client/Widgets/Class.fs
@@ -41,7 +41,7 @@ let view model dispatch =
 
     let selectedValue = model.Class |> Option.map string |> Option.defaultValue "Any"
 
-    div [ ClassName "class-filter" ] 
+    div [ ClassName "filter class-filter" ] 
         [
             div [ ClassName "class-filter-label" ] 
                 [

--- a/src/Client/Widgets/Gender.fs
+++ b/src/Client/Widgets/Gender.fs
@@ -40,7 +40,7 @@ let view model dispatch =
 
     let selectedValue = model.Gender |> Option.map string |> Option.defaultValue "Any"
 
-    div [ClassName "gender-filter"] 
+    div [ClassName "filter gender-filter"] 
         [
             div [ ClassName "gender-filter-label" ] 
                 [

--- a/src/Client/Widgets/Number.fs
+++ b/src/Client/Widgets/Number.fs
@@ -34,7 +34,7 @@ let view model dispatch =
 
     let selectedValue = model.Number |> Option.map string |> Option.defaultValue "Any"
 
-    div [ClassName "number-filter"] 
+    div [ClassName "filter number-filter"] 
         [
             div [ ClassName "number`-filter-label" ] 
                 [

--- a/src/Client/Widgets/Pattern.fs
+++ b/src/Client/Widgets/Pattern.fs
@@ -43,7 +43,7 @@ let view model dispatch =
 
     let selectedValue = model.SelectedPattern |> Option.defaultValue "Any"
 
-    div [ ClassName "pattern-filter" ] 
+    div [ ClassName "filter pattern-filter" ] 
         [
             div [ ClassName "pattern-filter-label" ] 
                 [

--- a/src/Client/Widgets/Regularity.fs
+++ b/src/Client/Widgets/Regularity.fs
@@ -33,7 +33,7 @@ let view model dispatch =
 
     let selectedValue = model.Regularity |> Option.map bool.AsString |> Option.defaultValue "Any"
 
-    div [ ClassName "regularity-filter" ]
+    div [ ClassName "filter regularity-filter" ]
         [
             div [ ClassName "regularity-filter-label" ] 
                 [

--- a/src/Client/scss/task.scss
+++ b/src/Client/scss/task.scss
@@ -107,10 +107,13 @@
         .filter-block-children{
             padding-bottom: 10px;
             display: flex;
+            flex-direction: column;
             justify-content: space-between;
-        }
 
-        
+            .filter:not(last-child) {
+                margin-bottom: 5px;
+            }
+        }
     }
 
     /* override Bulma's margin, we don't need it */
@@ -135,6 +138,9 @@
         }
     }
     
+    select {
+        text-align-last:center;
+    }
 }
 
 @media (min-width:641px)  { /* portrait tablets, portrait iPad, landscape e-readers, landscape 800x480 or 854x480 phones */ 
@@ -146,7 +152,12 @@
         &.children-hidden {
             .filter-block-children {
                 display: flex;
+                flex-direction: row;
                 justify-content: space-around;
+
+                .filter {
+                    margin-bottom: 0;
+                }
             }
         }
     }


### PR DESCRIPTION
closes #147 
Centered as per link in issue, works for me in Chrome.
Also fixed display on mobile - too many filters were stacking up in a line

After fix:
![image](https://user-images.githubusercontent.com/2879985/95749725-51b24080-0c9c-11eb-9a0a-9aaeb1af8075.png)
