### PR TITLE
fixed long label issue

### DIFF
--- a/src/Client/scss/task.scss
+++ b/src/Client/scss/task.scss
@@ -27,6 +27,9 @@
     .task-label.tag {
         width: 100%;
         font-size: 25px;
+        white-space: pre-wrap;
+        height: auto;
+        min-height: 2em;
     }
 
     .input {


### PR DESCRIPTION
closes #661 

unchanged in case of short questions. In case the line is filled in it wraps on the next one like that:
![image](https://user-images.githubusercontent.com/2879985/96050417-ddcd8f00-0e79-11eb-8f53-2453fc8e75ce.png)
