### PR TITLE
Introducing Farmer (#754)

### DIFF
--- a/CheckYourCzech.sln
+++ b/CheckYourCzech.sln
@@ -30,6 +30,8 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "WikiParsing.Tests", "tests\
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Storage", "src\Storage\Storage.fsproj", "{BA4E4D17-89DB-4577-AA9E-FFB3E11615B1}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Deployment", "deployment\Deployment\Deployment.fsproj", "{AC07EF15-1BBC-400E-8BD5-D49F1E7F3E16}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,6 +82,10 @@ Global
 		{BA4E4D17-89DB-4577-AA9E-FFB3E11615B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BA4E4D17-89DB-4577-AA9E-FFB3E11615B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BA4E4D17-89DB-4577-AA9E-FFB3E11615B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC07EF15-1BBC-400E-8BD5-D49F1E7F3E16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC07EF15-1BBC-400E-8BD5-D49F1E7F3E16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC07EF15-1BBC-400E-8BD5-D49F1E7F3E16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC07EF15-1BBC-400E-8BD5-D49F1E7F3E16}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/arm-template.json
+++ b/arm-template.json
@@ -10,10 +10,6 @@
 	}
   },
   "variables": {
-    "appServicePlan": "[concat(parameters('appName'), '-web-host')]",
-    "storage": "[concat(replace(parameters('appName'),'-', ''), 'storage')]",
-    "insights": "[concat(parameters('appName'), '-insights')]",
-    "location": "northeurope",
     "appInsightsTemplateName": "appInsightsTemplate",
     "appInsightsTemplateLink": "https://raw.githubusercontent.com/psfinaki/CheckYourCzech/master/arm-template-appinsights.json"
   },
@@ -37,83 +33,6 @@
           }
         }
       }
-    },
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "sku": {
-        "name": "Standard_LRS",
-        "tier": "Standard"
-      },
-      "kind": "Storage",
-      "name": "[variables('storage')]",
-      "apiVersion": "2017-10-01",
-      "location": "[variables('location')]"
-    },
-    {
-      "type": "Microsoft.Web/serverfarms",
-      "sku": {
-        "name": "B1"
-      },
-      "name": "[variables('appServicePlan')]",
-      "apiVersion": "2016-09-01",
-      "location": "[variables('location')]",
-      "properties": {
-        "name": "[variables('appserviceplan')]",
-        "perSiteScaling": false,
-        "reserved": false
-      }
-    },
-    {
-      "type": "Microsoft.Web/sites",
-      "name": "[parameters('appName')]",
-      "apiVersion": "2016-08-01",
-      "location": "[variables('location')]",
-      "properties": {
-        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlan'))]",
-        "siteConfig": {
-          "alwaysOn": true,
-          "appSettings": [
-            {
-              "name": "public_path",
-              "value": "./public"
-            },
-            {
-              "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-              "value": "[reference(variables('appInsightsTemplateName')).outputs.key.value]"
-            },
-            {
-              "name": "STORAGE_CONNECTIONSTRING",
-              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storage'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts/', variables('storage')), '2017-10-01').keys[0].value)]"
-            },
-            {
-              "name": "ASPNETCORE_ENVIRONMENT",
-              "value": "azure"
-            }
-          ]
-        }
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlan'))]",
-        "[resourceId('Microsoft.Storage/storageAccounts/', variables('storage'))]",
-        "[resourceId('Microsoft.Resources/deployments/', variables('appInsightsTemplateName'))]"
-      ],
-      "resources": [
-        {
-          "apiVersion": "2016-08-01",
-          "name": "Microsoft.ApplicationInsights.AzureWebSites",
-          "type": "siteextensions",
-          "dependsOn": [
-            "[resourceId('Microsoft.Web/sites/', parameters('appName'))]"
-          ],
-          "properties": {}
-        }
-      ]
     }
-  ],
-  "outputs": {
-    "webAppPassword": {
-      "type": "string",
-      "value": "[list(resourceId('Microsoft.Web/sites/config', parameters('appName'), 'publishingcredentials'), '2014-06-01').properties.publishingPassword]"
-    }
-  }
+  ]
 }

--- a/deployment/Deployment/Deployment.fsproj
+++ b/deployment/Deployment/Deployment.fsproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Infrastructure.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Common\Common.fsproj" />
+  </ItemGroup>
+  <Import Project="..\..\.paket\Paket.Restore.targets" />
+</Project>

--- a/deployment/Deployment/Infrastructure.fs
+++ b/deployment/Deployment/Infrastructure.fs
@@ -1,0 +1,34 @@
+﻿module Deployment.Infrastructure
+
+open Farmer
+open Farmer.Builders
+open Farmer.CoreTypes
+
+open Common.StringHelper
+
+let createDeployment appName = 
+    let storageName = appName |> append "-storage" |> remove "-"
+    let servicePlanName = appName |> append "-web-host"
+    let appInsightsName = appName |> append "-insights"
+
+    let storage = storageAccount {
+        name storageName
+        sku Storage.Sku.Standard_LRS
+    }
+
+    let webApp = webApp {
+        name appName
+        service_plan_name servicePlanName
+        sku WebApp.Sku.B1
+        always_on
+        link_to_unmanaged_app_insights (ResourceId.create appInsightsName)
+        setting "public_path" "./public"
+        setting "STORAGE_CONNECTIONSTRING" storage.Key
+        setting "ASPNETCORE_ENVIRONMENT" "azure"
+    }
+
+    arm {
+        location Location.NorthEurope
+        add_resource storage
+        add_resource webApp
+    }

--- a/deployment/Deployment/Program.fs
+++ b/deployment/Deployment/Program.fs
@@ -1,0 +1,13 @@
+﻿module Deployment.Program
+
+open Farmer
+
+[<EntryPoint>]
+let main args =
+    args
+    |> Seq.exactlyOne
+    |> Infrastructure.createDeployment
+    |> Writer.quickWrite "template"
+
+    0
+

--- a/deployment/Deployment/paket.references
+++ b/deployment/Deployment/paket.references
@@ -1,0 +1,3 @@
+group Deployment
+    FSharp.Core
+    Farmer

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -88,3 +88,9 @@ group Build
     nuget Fake.Core.Trace
     nuget Fake.IO.Zip
     github CompositionalIT/fshelpers src/FsHelpers/ArmHelper/ArmHelper.fs
+
+group Deployment
+    source https://api.nuget.org/v3/index.json
+    
+    nuget FSharp.Core
+    nuget Farmer

--- a/paket.lock
+++ b/paket.lock
@@ -171,7 +171,6 @@ NUGET
       System.Resources.Extensions (>= 4.6) - restriction: >= netstandard2.0
       System.Security.Permissions (>= 4.7) - restriction: && (< net472) (>= netstandard2.0)
       System.Threading.Tasks.Dataflow (>= 4.9) - restriction: >= netstandard2.0
-    Microsoft.Build.Tasks.Git (1.0) - restriction: >= netstandard2.0
     Microsoft.Build.Utilities.Core (16.7) - restriction: >= netstandard2.0
       Microsoft.Build.Framework (>= 16.7) - restriction: >= netstandard2.0
       Microsoft.VisualStudio.Setup.Configuration.Interop (>= 1.16.30) - restriction: >= net472
@@ -210,10 +209,6 @@ NUGET
       NETStandard.Library (>= 1.6.1) - restriction: && (< net452) (>= netstandard1.4)
       Newtonsoft.Json (>= 6.0.8) - restriction: >= net452
       Newtonsoft.Json (>= 9.0.1) - restriction: && (< net452) (>= netstandard1.4)
-    Microsoft.SourceLink.Common (1.0) - restriction: >= netstandard2.0
-    Microsoft.SourceLink.GitHub (1.0) - restriction: >= netstandard2.0
-      Microsoft.Build.Tasks.Git (>= 1.0)
-      Microsoft.SourceLink.Common (>= 1.0)
     Microsoft.VisualStudio.Setup.Configuration.Interop (1.16.30) - restriction: >= net472
     Microsoft.Win32.Primitives (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net452) (>= net46) (< netstandard1.4)) (>= netcoreapp5.0) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -226,12 +221,11 @@ NUGET
       System.Security.Principal.Windows (>= 4.7) - restriction: || (>= monoandroid) (>= monotouch) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
     Microsoft.Win32.SystemEvents (4.7) - restriction: >= netcoreapp3.0
       Microsoft.NETCore.Platforms (>= 3.1) - restriction: >= netcoreapp2.0
-    MSBuild.StructuredLogger (2.1.176) - restriction: || (>= net462) (>= netstandard2.0)
+    MSBuild.StructuredLogger (2.1.215) - restriction: || (>= net462) (>= netstandard2.0)
       Microsoft.Build (>= 16.4) - restriction: >= netstandard2.0
       Microsoft.Build.Framework (>= 16.4) - restriction: >= netstandard2.0
       Microsoft.Build.Tasks.Core (>= 16.4) - restriction: >= netstandard2.0
       Microsoft.Build.Utilities.Core (>= 16.4) - restriction: >= netstandard2.0
-      Microsoft.SourceLink.GitHub (>= 1.0) - restriction: >= netstandard2.0
     NETStandard.Library (2.0.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< xamarinios)) (&& (< net45) (>= net452) (>= netstandard1.4)) (&& (< net45) (>= netstandard1.4) (< netstandard2.0)) (&& (< net452) (>= netstandard1.3)) (&& (< net452) (>= netstandard1.4)) (&& (< net46) (>= netstandard1.6) (< netstandard2.0)) (&& (>= netcoreapp5.0) (< netstandard2.0))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
       Microsoft.Win32.Primitives (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= net46) (< netstandard1.4)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
@@ -1135,12 +1129,12 @@ NUGET
     Fable.Browser.Blob (1.1) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
-    Fable.Browser.Dom (2.1) - restriction: >= netstandard2.0
+    Fable.Browser.Dom (2.1.2) - restriction: >= netstandard2.0
       Fable.Browser.Blob (>= 1.1) - restriction: >= netstandard2.0
       Fable.Browser.Event (>= 1.2.1) - restriction: >= netstandard2.0
       Fable.Browser.WebStorage (>= 1.0) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.1) - restriction: >= netstandard2.0
     Fable.Browser.Event (1.2.1) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
@@ -1204,7 +1198,7 @@ NUGET
       System.Reflection.Metadata (>= 1.6) - restriction: || (>= net461) (>= netstandard2.0)
       System.Reflection.TypeExtensions (>= 4.3) - restriction: && (< net461) (>= netstandard2.0)
       System.Runtime.Loader (>= 4.0) - restriction: && (< net461) (>= netstandard2.0)
-    FSharp.Core (4.7.2) - restriction: >= netstandard2.0
+    FSharp.Core (5.0) - restriction: >= netstandard2.0
     Fulma (2.10)
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       Fable.React (>= 5.1) - restriction: >= netstandard2.0
@@ -1389,7 +1383,7 @@ NUGET
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
       Selenium.WebDriver (>= 3.141) - restriction: >= netstandard2.0
       System.Drawing.Common (>= 4.6) - restriction: >= netstandard2.0
-    FSharp.Core (4.7.2)
+    FSharp.Core (5.0)
     Microsoft.CodeCoverage (16.7.1) - restriction: || (>= net45) (>= netcoreapp2.1)
     Microsoft.CSharp (4.7) - restriction: || (&& (< netstandard1.3) (>= uap10.0)) (&& (< netstandard2.0) (>= uap10.0))
     Microsoft.NET.Test.Sdk (16.7.1)
@@ -1652,12 +1646,12 @@ NUGET
 GROUP Core
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    FSharp.Core (4.7.2)
+    FSharp.Core (5.0)
 
 GROUP Core.IntegrationTests
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (4.7.2)
+    FSharp.Core (5.0)
     Microsoft.CodeCoverage (16.7.1) - restriction: || (>= net45) (>= netcoreapp2.1)
     Microsoft.CSharp (4.7) - restriction: || (&& (< netstandard1.3) (>= uap10.0)) (&& (< netstandard2.0) (>= uap10.0))
     Microsoft.NET.Test.Sdk (16.7.1)
@@ -1912,7 +1906,7 @@ NUGET
 GROUP Core.Tests
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (4.7.2)
+    FSharp.Core (5.0)
     Microsoft.CodeCoverage (16.7.1) - restriction: || (>= net45) (>= netcoreapp2.1)
     Microsoft.CSharp (4.7) - restriction: || (&& (< netstandard1.3) (>= uap10.0)) (&& (< netstandard2.0) (>= uap10.0))
     Microsoft.NET.Test.Sdk (16.7.1)
@@ -2164,10 +2158,19 @@ NUGET
       xunit.extensibility.core (2.4.1) - restriction: >= netstandard1.1
     xunit.runner.visualstudio (2.4.3)
 
+GROUP Deployment
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    Farmer (1.2)
+      FSharp.Core (>= 4.7.1) - restriction: >= netstandard2.0
+      Newtonsoft.Json (>= 12.0.2) - restriction: >= netstandard2.0
+    FSharp.Core (5.0)
+    Newtonsoft.Json (12.0.3) - restriction: >= netstandard2.0
+
 GROUP Scraper
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    FSharp.Core (4.7.2)
+    FSharp.Core (5.0)
     Microsoft.ApplicationInsights (2.15)
       System.Diagnostics.DiagnosticSource (>= 4.6) - restriction: || (&& (>= net452) (< netstandard2.0)) (&& (< net452) (>= netstandard2.0)) (>= net46)
       System.Memory (>= 4.5.4) - restriction: || (&& (>= net452) (< netstandard2.0)) (&& (< net452) (>= netstandard2.0)) (>= net46)
@@ -2185,7 +2188,7 @@ NUGET
 GROUP Server
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    FSharp.Core (4.7.2)
+    FSharp.Core (5.0)
     Giraffe (3.4)
       FSharp.Core (>= 4.5.2) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
@@ -3008,7 +3011,7 @@ NUGET
 GROUP Storage
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    FSharp.Core (4.7.2)
+    FSharp.Core (5.0)
     Microsoft.Azure.KeyVault.Core (3.0.5) - restriction: || (>= net45) (>= wp8)
       Microsoft.Rest.ClientRuntime (>= 2.3.20 < 3.0) - restriction: || (&& (>= net452) (< netstandard1.4)) (&& (< net452) (>= netstandard1.4) (< netstandard2.0)) (&& (< net452) (>= netstandard2.0)) (>= net461)
       Microsoft.Rest.ClientRuntime.Azure (>= 3.3.18 < 4.0) - restriction: || (&& (>= net452) (< netstandard1.4)) (&& (< net452) (>= netstandard1.4) (< netstandard2.0)) (&& (< net452) (>= netstandard2.0)) (>= net461)
@@ -3636,7 +3639,7 @@ NUGET
 GROUP WikiParsing
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    FSharp.Core (4.7.2) - restriction: || (>= net45) (>= netstandard2.0)
+    FSharp.Core (5.0) - restriction: || (>= net45) (>= netstandard2.0)
     FSharp.Data (3.0.0-beta3)
       FSharp.Core (>= 4.0.0.1) - restriction: >= net45
       FSharp.Core (>= 4.3.4) - restriction: && (< net45) (>= netstandard2.0)
@@ -3644,7 +3647,7 @@ NUGET
 GROUP WikiParsing.Tests
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (4.7.2)
+    FSharp.Core (5.0)
     Microsoft.CodeCoverage (16.7.1) - restriction: || (>= net45) (>= netcoreapp2.1)
     Microsoft.CSharp (4.7) - restriction: || (&& (< netstandard1.3) (>= uap10.0)) (&& (< netstandard2.0) (>= uap10.0))
     Microsoft.NET.Test.Sdk (16.7.1)


### PR DESCRIPTION
So now we have the `Deployment` project with the `Infrastructure` module instead of the most part of the `arm-template.json`. A small part of it still stays as Farmer does not support all the Application Insights settings that we need. They are plugged in via `link_to_unmanaged_app_insights` in the `webApp` of `Infrastructure`.

In general yes this is much better and concise than raw json. Azure Pipelines are adjusted.