### PR TITLE
Removed redundant FSharp.Core reference in dependencies

### DIFF
--- a/deployment/Deployment/paket.references
+++ b/deployment/Deployment/paket.references
@@ -1,3 +1,2 @@
 group Deployment
-    FSharp.Core
     Farmer

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,13 +5,10 @@ group WikiParsing
 
 group Core
     source https://api.nuget.org/v3/index.json
-	
-	nuget FSharp.Core
 
 group Storage
     source https://api.nuget.org/v3/index.json
 
-	nuget FSharp.Core
 	nuget WindowsAzure.Storage
 
 group Server
@@ -26,7 +23,6 @@ group Server
 group Scraper
     source https://api.nuget.org/v3/index.json
 
-	nuget FSharp.Core
 	nuget Microsoft.ApplicationInsights
 	
 group Client
@@ -45,7 +41,6 @@ group Client
 group Core.Tests
 	source https://nuget.org/api/v2
 
-	nuget FSharp.Core
 	nuget xunit
 	nuget xunit.runner.visualstudio
     nuget Microsoft.NET.Test.Sdk
@@ -53,7 +48,6 @@ group Core.Tests
 group Core.IntegrationTests
 	source https://nuget.org/api/v2
 
-	nuget FSharp.Core
 	nuget xunit
 	nuget xunit.runner.visualstudio
     nuget Microsoft.NET.Test.Sdk
@@ -64,14 +58,12 @@ group Client.UiTests
     nuget Canopy
 	nuget xunit
 	nuget xunit.runner.visualstudio
-    nuget FSharp.Core
     nuget Selenium.WebDriver.ChromeDriver
 	nuget Microsoft.NET.Test.Sdk
 
 group WikiParsing.Tests
 	source https://nuget.org/api/v2
 
-	nuget FSharp.Core
 	nuget xunit
 	nuget xunit.runner.visualstudio
     nuget Microsoft.NET.Test.Sdk
@@ -79,5 +71,4 @@ group WikiParsing.Tests
 group Deployment
     source https://api.nuget.org/v3/index.json
     
-    nuget FSharp.Core
     nuget Farmer

--- a/paket.lock
+++ b/paket.lock
@@ -531,14 +531,11 @@ NUGET
     xunit.runner.visualstudio (2.4.3)
 
 GROUP Core
-NUGET
-  remote: https://api.nuget.org/v3/index.json
-    FSharp.Core (5.0)
+
 
 GROUP Core.IntegrationTests
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (5.0)
     Microsoft.CodeCoverage (16.7.1) - restriction: || (>= net45) (>= netcoreapp2.1)
     Microsoft.CSharp (4.7) - restriction: || (&& (< netstandard1.3) (>= uap10.0)) (&& (< netstandard2.0) (>= uap10.0))
     Microsoft.NET.Test.Sdk (16.7.1)
@@ -793,7 +790,6 @@ NUGET
 GROUP Core.Tests
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (5.0)
     Microsoft.CodeCoverage (16.7.1) - restriction: || (>= net45) (>= netcoreapp2.1)
     Microsoft.CSharp (4.7) - restriction: || (&& (< netstandard1.3) (>= uap10.0)) (&& (< netstandard2.0) (>= uap10.0))
     Microsoft.NET.Test.Sdk (16.7.1)
@@ -1057,7 +1053,6 @@ NUGET
 GROUP Scraper
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    FSharp.Core (5.0)
     Microsoft.ApplicationInsights (2.15)
       System.Diagnostics.DiagnosticSource (>= 4.6) - restriction: || (&& (>= net452) (< netstandard2.0)) (&& (< net452) (>= netstandard2.0)) (>= net46)
       System.Memory (>= 4.5.4) - restriction: || (&& (>= net452) (< netstandard2.0)) (&& (< net452) (>= netstandard2.0)) (>= net46)
@@ -1898,7 +1893,6 @@ NUGET
 GROUP Storage
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    FSharp.Core (5.0)
     Microsoft.Azure.KeyVault.Core (3.0.5) - restriction: || (>= net45) (>= wp8)
       Microsoft.Rest.ClientRuntime (>= 2.3.20 < 3.0) - restriction: || (&& (>= net452) (< netstandard1.4)) (&& (< net452) (>= netstandard1.4) (< netstandard2.0)) (&& (< net452) (>= netstandard2.0)) (>= net461)
       Microsoft.Rest.ClientRuntime.Azure (>= 3.3.18 < 4.0) - restriction: || (&& (>= net452) (< netstandard1.4)) (&& (< net452) (>= netstandard1.4) (< netstandard2.0)) (&& (< net452) (>= netstandard2.0)) (>= net461)
@@ -2534,7 +2528,6 @@ NUGET
 GROUP WikiParsing.Tests
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (5.0)
     Microsoft.CodeCoverage (16.7.1) - restriction: || (>= net45) (>= netcoreapp2.1)
     Microsoft.CSharp (4.7) - restriction: || (&& (< netstandard1.3) (>= uap10.0)) (&& (< netstandard2.0) (>= uap10.0))
     Microsoft.NET.Test.Sdk (16.7.1)

--- a/src/Core/paket.references
+++ b/src/Core/paket.references
@@ -1,2 +1,1 @@
 group Core
-	FSharp.Core

--- a/src/Scraper/paket.references
+++ b/src/Scraper/paket.references
@@ -1,3 +1,2 @@
 group Scraper
-	FSharp.Core
 	Microsoft.ApplicationInsights

--- a/src/Storage/paket.references
+++ b/src/Storage/paket.references
@@ -1,3 +1,2 @@
 group Storage
-	FSharp.Core
 	WindowsAzure.Storage

--- a/tests/Client.UiTests/paket.references
+++ b/tests/Client.UiTests/paket.references
@@ -2,6 +2,5 @@ group Client.UiTests
     Canopy
     xunit
     xunit.runner.visualstudio
-    FSharp.Core
     Selenium.WebDriver.ChromeDriver
     Microsoft.NET.Test.Sdk

--- a/tests/Core.IntegrationTests/paket.references
+++ b/tests/Core.IntegrationTests/paket.references
@@ -1,5 +1,4 @@
 group Core.IntegrationTests
-	FSharp.Core
 	xunit
 	xunit.runner.visualstudio
     Microsoft.NET.Test.Sdk

--- a/tests/Core.Tests/paket.references
+++ b/tests/Core.Tests/paket.references
@@ -1,5 +1,4 @@
 group Core.Tests
-	FSharp.Core
 	xunit
 	xunit.runner.visualstudio
     Microsoft.NET.Test.Sdk

--- a/tests/WikiParsing.Tests/paket.references
+++ b/tests/WikiParsing.Tests/paket.references
@@ -1,5 +1,4 @@
 group WikiParsing.Tests
-	FSharp.Core
 	xunit
 	xunit.runner.visualstudio
     Microsoft.NET.Test.Sdk


### PR DESCRIPTION
`FSharp.Core` nuget package is implicitly referenced with the framework ([1](https://fsharp.github.io/FSharp.Compiler.Service/corelib.html), [2](https://devblogs.microsoft.com/dotnet/announcing-f-5/#comment-8100)) so we don't need to specify it explicitly (as we need framework versions anyway).