### PR TITLE
Using YAML pipeline for releases (#517)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,71 +8,231 @@ resources:
   - repository: self
     type: git
     ref: master
+   
+variables:
+  appNameExperimental: 'check-your-czech-x'
+  appNameProduction: 'check-your-czech'
+  adminEmail: 'petersemkin@gmail.com'
+
+stages:
+- stage: Build
+  jobs:
+  - job: Job_1
+    displayName: Agent job
+    pool:
+      vmImage: windows-2019
+    steps:
+    - checkout: self
     
-jobs:
-- job: Job_1
-  displayName: Agent job
-  pool:
-    vmImage: windows-2019
-  steps:
-  - checkout: self
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Repo
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)
-      ArtifactName: Repo
-  - task: DotNetCoreCLI@2
-    displayName: Restore Tools
-    inputs:
-      command: custom
-      custom: tool
-      arguments: restore
-  - task: DotNetCoreCLI@2
-    displayName: Restore Backend Packages
-    inputs:
-      command: custom
-      custom: paket
-      arguments: restore
-  - task: Yarn@2
-    displayName: Restore Frontend Packages
-    inputs:
-      Arguments: install --frozen-lockfile
-  - task: DotNetCoreCLI@2
-    displayName: Build
-    inputs:
-      command: custom
-      custom: fsi
-      arguments: build.fsx
-  - task: DotNetCoreCLI@2
-    displayName: Test
-    inputs:
-      command: test
-      arguments: --filter FullyQualifiedName!~Client.UiTests
-  - task: DotNetCoreCLI@2
-    displayName: Publish Server
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: $(Build.SourcesDirectory)/src/Server
-      arguments: -c release -o $(Build.SourcesDirectory)/deploy -r win-x64
-      zipAfterPublish: false
-      modifyOutputPath: false
-  - task: CopyFiles@2
-    displayName: Publish Client
-    inputs:
-      SourceFolder: $(Build.SourcesDirectory)/src/Client/public
-      TargetFolder: $(Build.SourcesDirectory)/deploy/public
-  - task: DotNetCoreCLI@2
-    displayName: Publish Scraper
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: $(Build.SourcesDirectory)/src/Scraper
-      arguments: -c release -o $(Build.SourcesDirectory)/deploy/app_data/Jobs/Continuous/Scraper -r win-x64
-      zipAfterPublish: false
-      modifyOutputPath: false
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Deploy
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/deploy
-      ArtifactName: Deploy
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Repo
+      inputs:
+        PathtoPublish: $(Build.SourcesDirectory)
+        ArtifactName: Repo
+
+    - task: DotNetCoreCLI@2
+      displayName: Restore Tools
+      inputs:
+        command: custom
+        custom: tool
+        arguments: restore
+
+    - task: DotNetCoreCLI@2
+      displayName: Restore Backend Packages
+      inputs:
+        command: custom
+        custom: paket
+        arguments: restore
+
+    - task: Yarn@2
+      displayName: Restore Frontend Packages
+      inputs:
+        Arguments: install --frozen-lockfile
+
+    - task: DotNetCoreCLI@2
+      displayName: Build
+      inputs:
+        command: custom
+        custom: fsi
+        arguments: build.fsx
+
+    - task: DotNetCoreCLI@2
+      displayName: Test
+      inputs:
+        command: test
+        arguments: --filter FullyQualifiedName!~Client.UiTests
+
+    - task: DotNetCoreCLI@2
+      displayName: Publish Server
+      inputs:
+        command: publish
+        publishWebProjects: false
+        projects: $(Build.SourcesDirectory)/src/Server
+        arguments: -c release -o $(Build.SourcesDirectory)/deploy -r win-x64
+        zipAfterPublish: false
+        modifyOutputPath: false
+
+    - task: CopyFiles@2
+      displayName: Publish Client
+      inputs:
+        SourceFolder: $(Build.SourcesDirectory)/src/Client/public
+        TargetFolder: $(Build.SourcesDirectory)/deploy/public
+
+    - task: DotNetCoreCLI@2
+      displayName: Publish Scraper
+      inputs:
+        command: publish
+        publishWebProjects: false
+        projects: $(Build.SourcesDirectory)/src/Scraper
+        arguments: -c release -o $(Build.SourcesDirectory)/deploy/app_data/Jobs/Continuous/Scraper -r win-x64
+        zipAfterPublish: false
+        modifyOutputPath: false
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Deploy
+      inputs:
+        PathtoPublish: $(Build.SourcesDirectory)/deploy
+        ArtifactName: Deploy
+
+- stage: Experimental
+  jobs:
+  - deployment: Job_1
+    displayName: Experimental
+    pool:
+      vmImage: windows-2019
+    environment: Experimental
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - task: ArchiveFiles@2
+            displayName: 'Zip app'
+            inputs:
+              rootFolderOrFile: '$(Pipeline.Workspace)/Deploy'
+              includeRootFolder: false
+              archiveFile: deploy.zip
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Restore tools'
+            inputs:
+              command: custom
+              custom: tool
+              arguments: restore
+              workingDirectory: '$(Pipeline.Workspace)/Repo'
+          
+          - task: DotNetCoreCLI@2
+            displayName: 'Restore packages'
+            inputs:
+              command: custom
+              custom: paket
+              arguments: restore
+              workingDirectory: '$(Pipeline.Workspace)/Repo'
+          
+          - task: DotNetCoreCLI@2
+            displayName: 'Generate ARM template from Farmer'
+            inputs:
+              command: run
+              arguments: '$(appNameExperimental)'
+              workingDirectory: '$(Pipeline.Workspace)/Repo/deployment/Deployment'
+          
+          - task: AzureResourceGroupDeployment@2
+            displayName: 'Create Application Insights'
+            inputs:
+              azureSubscription: 'Visual Studio Enterprise Subscription (a7b6f428-0ed2-4721-9548-d17c361d9b77)'
+              resourceGroupName: '$(appNameExperimental)'
+              location: 'North Europe'
+              csmFile: '$(Pipeline.Workspace)/Repo/arm-template.json'
+              overrideParameters: '-appName $(appNameExperimental) -adminEmail $(adminEmail)'
+              deploymentName: '$(appNameExperimental)'
+          
+          - task: AzureResourceGroupDeployment@2
+            displayName: 'Create other Azure resources'
+            inputs:
+              azureSubscription: 'Visual Studio Enterprise Subscription (a7b6f428-0ed2-4721-9548-d17c361d9b77)'
+              resourceGroupName: '$(appNameExperimental)'
+              location: 'North Europe'
+              csmFile: '$(Pipeline.Workspace)/Repo/deployment/Deployment/template.json'
+              deploymentName: '$(appNameExperimental)'
+          
+          - task: AzureCLI@1
+            displayName: 'Deploy app'
+            inputs:
+              azureSubscription: 'Visual Studio Enterprise Subscription (a7b6f428-0ed2-4721-9548-d17c361d9b77)'
+              scriptLocation: inlineScript
+              inlineScript: 'az webapp deployment source config-zip --resource-group $(appNameExperimental) --name $(appNameExperimental) --src "deploy.zip"'
+          
+          - task: DotNetCoreCLI@2
+            displayName: 'Run E2E tests'
+            inputs:
+              command: test
+              arguments: '--filter FullyQualifiedName~Client.UiTests'
+              workingDirectory: '$(Pipeline.Workspace)/Repo'
+            env:
+              SERVER_URL: 'https://$(appNameExperimental).azurewebsites.net/'
+
+- stage: Production
+  jobs:
+  - deployment: Job_1
+    displayName: Production
+    pool:
+      vmImage: windows-2019
+    environment: Production
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - task: ArchiveFiles@2
+            displayName: 'Zip app'
+            inputs:
+              rootFolderOrFile: '$(Pipeline.Workspace)/Deploy'
+              includeRootFolder: false
+              archiveFile: deploy.zip
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Restore tools'
+            inputs:
+              command: custom
+              custom: tool
+              arguments: restore
+              workingDirectory: '$(Pipeline.Workspace)/Repo'
+          
+          - task: DotNetCoreCLI@2
+            displayName: 'Restore packages'
+            inputs:
+              command: custom
+              custom: paket
+              arguments: restore
+              workingDirectory: '$(Pipeline.Workspace)/Repo'
+          
+          - task: DotNetCoreCLI@2
+            displayName: 'Generate ARM template from Farmer'
+            inputs:
+              command: run
+              arguments: '$(appNameProduction)'
+              workingDirectory: '$(Pipeline.Workspace)/Repo/deployment/Deployment'
+          
+          - task: AzureResourceGroupDeployment@2
+            displayName: 'Create Application Insights'
+            inputs:
+              azureSubscription: 'Visual Studio Enterprise Subscription (a7b6f428-0ed2-4721-9548-d17c361d9b77)'
+              resourceGroupName: '$(appNameProduction)'
+              location: 'North Europe'
+              csmFile: '$(Pipeline.Workspace)/Repo/arm-template.json'
+              overrideParameters: '-appName $(appNameProduction) -adminEmail $(adminEmail)'
+              deploymentName: '$(appNameProduction)'
+          
+          - task: AzureResourceGroupDeployment@2
+            displayName: 'Create other Azure resources'
+            inputs:
+              azureSubscription: 'Visual Studio Enterprise Subscription (a7b6f428-0ed2-4721-9548-d17c361d9b77)'
+              resourceGroupName: '$(appNameProduction)'
+              location: 'North Europe'
+              csmFile: '$(Pipeline.Workspace)/Repo/deployment/Deployment/template.json'
+              deploymentName: '$(appNameProduction)'
+          
+          - task: AzureCLI@1
+            displayName: 'Deploy app'
+            inputs:
+              azureSubscription: 'Visual Studio Enterprise Subscription (a7b6f428-0ed2-4721-9548-d17c361d9b77)'
+              scriptLocation: inlineScript
+              inlineScript: 'az webapp deployment source config-zip --resource-group $(appNameProduction) --name $(appNameProduction) --src "deploy.zip"'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ stages:
 - stage: Experimental
   jobs:
   - deployment: Job_1
-    displayName: Experimental
+    displayName: Agent job
     pool:
       vmImage: windows-2019
     environment: Experimental
@@ -173,7 +173,7 @@ stages:
 - stage: Production
   jobs:
   - deployment: Job_1
-    displayName: Production
+    displayName: Agent job
     pool:
       vmImage: windows-2019
     environment: Production


### PR DESCRIPTION
closes #517.

The pipeline has duplication because it's meant to barely replace whatever we have now in "Releases" (which has duplication). Also, I want to move to deployment slots instead of parallel deployments, so this will be modified anyway.