### PR TITLE
Moving to deployment slots instead of two webs (#784)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,45 +7,37 @@ resources:
   repositories:
   - repository: self
     type: git
-    ref: master
    
 variables:
-  appNameExperimental: 'check-your-czech-x'
-  appNameProduction: 'check-your-czech'
+  appName: check-your-czech
+  experimentalSlotName: exp
   adminEmail: 'petersemkin@gmail.com'
+  subscription: Visual Studio Enterprise Subscription (a7b6f428-0ed2-4721-9548-d17c361d9b77)
 
 stages:
 - stage: Build
   jobs:
-  - job: Job_1
-    displayName: Agent job
+  - job: Job1
+    displayName: 'Build, Test, Publish'
     pool:
       vmImage: windows-2019
     steps:
-    - checkout: self
-    
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Repo
-      inputs:
-        PathtoPublish: $(Build.SourcesDirectory)
-        ArtifactName: Repo
-
     - task: DotNetCoreCLI@2
-      displayName: Restore Tools
+      displayName: Restore tools
       inputs:
         command: custom
         custom: tool
         arguments: restore
 
     - task: DotNetCoreCLI@2
-      displayName: Restore Backend Packages
+      displayName: Restore backend packages
       inputs:
         command: custom
         custom: paket
         arguments: restore
 
     - task: Yarn@2
-      displayName: Restore Frontend Packages
+      displayName: Restore frontend packages
       inputs:
         Arguments: install --frozen-lockfile
 
@@ -67,37 +59,98 @@ stages:
       inputs:
         command: publish
         publishWebProjects: false
-        projects: $(Build.SourcesDirectory)/src/Server
-        arguments: -c release -o $(Build.SourcesDirectory)/deploy -r win-x64
+        projects: src/Server
+        arguments: -c release -o deploy -r win-x64
         zipAfterPublish: false
         modifyOutputPath: false
 
     - task: CopyFiles@2
       displayName: Publish Client
       inputs:
-        SourceFolder: '$(Build.SourcesDirectory)/src/Client/public'
-        TargetFolder: '$(Build.SourcesDirectory)/deploy/public'
+        SourceFolder: src/Client/public
+        TargetFolder: deploy/public
 
     - task: DotNetCoreCLI@2
       displayName: Publish Scraper
       inputs:
         command: publish
         publishWebProjects: false
-        projects: $(Build.SourcesDirectory)/src/Scraper
-        arguments: -c release -o $(Build.SourcesDirectory)/deploy/app_data/Jobs/Continuous/Scraper -r win-x64
+        projects: src/Scraper
+        arguments: -c release -o deploy/app_data/Jobs/Continuous/Scraper -r win-x64
         zipAfterPublish: false
         modifyOutputPath: false
 
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Deploy
+    - task: ArchiveFiles@2
+      displayName: Zip app
       inputs:
-        PathtoPublish: $(Build.SourcesDirectory)/deploy
-        ArtifactName: Deploy
+        rootFolderOrFile: deploy
+        includeRootFolder: false
+        archiveFile: deploy.zip
 
-- stage: Experimental
+    - publish: deploy.zip
+      artifact: WebApp
+
+- stage: Release
+  dependsOn: Build
   jobs:
-  - deployment: Job_1
-    displayName: Agent job
+  - job: Job1
+    displayName: Create resources
+    pool:
+      vmImage: windows-2019
+    steps:
+    - download: current
+      artifact: WebApp
+
+    - task: DotNetCoreCLI@2
+      displayName: Restore tools
+      inputs:
+        command: custom
+        custom: tool
+        arguments: restore
+
+    - task: DotNetCoreCLI@2
+      displayName: Restore backend packages
+      inputs:
+        command: custom
+        custom: paket
+        arguments: restore
+
+    - task: DotNetCoreCLI@2
+      displayName: Generate ARM template from Farmer
+      inputs:
+        command: run
+        arguments: $(appName)
+        workingDirectory: deployment/Deployment
+    
+    - task: AzureResourceGroupDeployment@2
+      displayName: Create Application Insights
+      inputs:
+        azureSubscription: $(subscription)
+        resourceGroupName: $(appName)
+        location: North Europe
+        csmFile: arm-template.json
+        overrideParameters: -appName $(appName) -adminEmail $(adminEmail)
+        deploymentName: $(appName)
+    
+    - task: AzureResourceGroupDeployment@2
+      displayName: Create other Azure resources
+      inputs:
+        azureSubscription: $(subscription)
+        resourceGroupName: $(appName)
+        location: North Europe
+        csmFile: deployment/Deployment/template.json
+        deploymentName: $(appName)
+
+    - task: AzureCLI@1
+      displayName: Create experimental slot
+      inputs:
+        azureSubscription: $(subscription)
+        scriptLocation: inlineScript
+        inlineScript: az webapp deployment slot create -n $(appName) -g $(appName) -s $(experimentalSlotName)
+
+  - deployment: Job2
+    displayName: Deploy to Experimental
+    dependsOn: Job1
     pool:
       vmImage: windows-2019
     environment: Experimental
@@ -105,75 +158,48 @@ stages:
       runOnce:
         deploy:
           steps:
-          - task: ArchiveFiles@2
-            displayName: 'Zip app'
+          - task: AzureWebApp@1
             inputs:
-              rootFolderOrFile: '$(Pipeline.Workspace)/Deploy'
-              includeRootFolder: false
-              archiveFile: deploy.zip
+              azureSubscription: $(subscription)
+              appType: webApp
+              appName: $(appName)
+              deployToSlotOrASE: true
+              resourceGroupName: $(appName)
+              slotName: $(experimentalSlotName)
+              package: $(Pipeline.Workspace)/WebApp/deploy.zip
+              deploymentMethod: zipDeploy
 
-          - task: DotNetCoreCLI@2
-            displayName: 'Restore tools'
-            inputs:
-              command: custom
-              custom: tool
-              arguments: restore
-              workingDirectory: '$(Pipeline.Workspace)/Repo'
-          
-          - task: DotNetCoreCLI@2
-            displayName: 'Restore packages'
-            inputs:
-              command: custom
-              custom: paket
-              arguments: restore
-              workingDirectory: '$(Pipeline.Workspace)/Repo'
-          
-          - task: DotNetCoreCLI@2
-            displayName: 'Generate ARM template from Farmer'
-            inputs:
-              command: run
-              arguments: '$(appNameExperimental)'
-              workingDirectory: '$(Pipeline.Workspace)/Repo/deployment/Deployment'
-          
-          - task: AzureResourceGroupDeployment@2
-            displayName: 'Create Application Insights'
-            inputs:
-              azureSubscription: 'Visual Studio Enterprise Subscription (a7b6f428-0ed2-4721-9548-d17c361d9b77)'
-              resourceGroupName: '$(appNameExperimental)'
-              location: 'North Europe'
-              csmFile: '$(Pipeline.Workspace)/Repo/arm-template.json'
-              overrideParameters: '-appName $(appNameExperimental) -adminEmail $(adminEmail)'
-              deploymentName: '$(appNameExperimental)'
-          
-          - task: AzureResourceGroupDeployment@2
-            displayName: 'Create other Azure resources'
-            inputs:
-              azureSubscription: 'Visual Studio Enterprise Subscription (a7b6f428-0ed2-4721-9548-d17c361d9b77)'
-              resourceGroupName: '$(appNameExperimental)'
-              location: 'North Europe'
-              csmFile: '$(Pipeline.Workspace)/Repo/deployment/Deployment/template.json'
-              deploymentName: '$(appNameExperimental)'
-          
-          - task: AzureCLI@1
-            displayName: 'Deploy app'
-            inputs:
-              azureSubscription: 'Visual Studio Enterprise Subscription (a7b6f428-0ed2-4721-9548-d17c361d9b77)'
-              scriptLocation: inlineScript
-              inlineScript: 'az webapp deployment source config-zip --resource-group $(appNameExperimental) --name $(appNameExperimental) --src "deploy.zip"'
-          
-          - task: DotNetCoreCLI@2
-            displayName: 'Run E2E tests'
-            inputs:
-              command: test
-              arguments: '--filter FullyQualifiedName~Client.UiTests'
-              workingDirectory: '$(Pipeline.Workspace)/Repo'
-            env:
-              SERVER_URL: 'https://$(appNameExperimental).azurewebsites.net/'
+  - job: Job3
+    displayName: Test Experimental deployment
+    dependsOn: Job2
+    pool:
+      vmImage: windows-2019
+    steps:
+    - task: DotNetCoreCLI@2
+      displayName: Restore tools
+      inputs:
+        command: custom
+        custom: tool
+        arguments: restore
 
-- stage: Production
-  jobs:
-  - deployment: Job_1
-    displayName: Agent job
+    - task: DotNetCoreCLI@2
+      displayName: Restore backend packages
+      inputs:
+        command: custom
+        custom: paket
+        arguments: restore
+
+    - task: DotNetCoreCLI@2
+      displayName: Run E2E tests
+      inputs:
+        command: test
+        arguments: '--filter FullyQualifiedName~Client.UiTests'
+      env:
+        SERVER_URL: https://$(appName)-$(experimentalSlotName).azurewebsites.net/
+
+  - deployment: Job4
+    displayName: Deploy to Production
+    dependsOn: Job3
     pool:
       vmImage: windows-2019
     environment: Production
@@ -181,58 +207,11 @@ stages:
       runOnce:
         deploy:
           steps:
-          - task: ArchiveFiles@2
-            displayName: 'Zip app'
+          - task: AzureAppServiceManage@0
+            displayName: Swap slots
             inputs:
-              rootFolderOrFile: '$(Pipeline.Workspace)/Deploy'
-              includeRootFolder: false
-              archiveFile: deploy.zip
-
-          - task: DotNetCoreCLI@2
-            displayName: 'Restore tools'
-            inputs:
-              command: custom
-              custom: tool
-              arguments: restore
-              workingDirectory: '$(Pipeline.Workspace)/Repo'
-          
-          - task: DotNetCoreCLI@2
-            displayName: 'Restore packages'
-            inputs:
-              command: custom
-              custom: paket
-              arguments: restore
-              workingDirectory: '$(Pipeline.Workspace)/Repo'
-          
-          - task: DotNetCoreCLI@2
-            displayName: 'Generate ARM template from Farmer'
-            inputs:
-              command: run
-              arguments: '$(appNameProduction)'
-              workingDirectory: '$(Pipeline.Workspace)/Repo/deployment/Deployment'
-          
-          - task: AzureResourceGroupDeployment@2
-            displayName: 'Create Application Insights'
-            inputs:
-              azureSubscription: 'Visual Studio Enterprise Subscription (a7b6f428-0ed2-4721-9548-d17c361d9b77)'
-              resourceGroupName: '$(appNameProduction)'
-              location: 'North Europe'
-              csmFile: '$(Pipeline.Workspace)/Repo/arm-template.json'
-              overrideParameters: '-appName $(appNameProduction) -adminEmail $(adminEmail)'
-              deploymentName: '$(appNameProduction)'
-          
-          - task: AzureResourceGroupDeployment@2
-            displayName: 'Create other Azure resources'
-            inputs:
-              azureSubscription: 'Visual Studio Enterprise Subscription (a7b6f428-0ed2-4721-9548-d17c361d9b77)'
-              resourceGroupName: '$(appNameProduction)'
-              location: 'North Europe'
-              csmFile: '$(Pipeline.Workspace)/Repo/deployment/Deployment/template.json'
-              deploymentName: '$(appNameProduction)'
-          
-          - task: AzureCLI@1
-            displayName: 'Deploy app'
-            inputs:
-              azureSubscription: 'Visual Studio Enterprise Subscription (a7b6f428-0ed2-4721-9548-d17c361d9b77)'
-              scriptLocation: inlineScript
-              inlineScript: 'az webapp deployment source config-zip --resource-group $(appNameProduction) --name $(appNameProduction) --src "deploy.zip"'
+              azureSubscription: $(subscription)
+              Action: Swap Slots
+              WebAppName: $(appName)
+              ResourceGroupName: $(appName)
+              SourceSlot: $(experimentalSlotName)

--- a/deployment/Deployment/Infrastructure.fs
+++ b/deployment/Deployment/Infrastructure.fs
@@ -19,7 +19,7 @@ let createDeployment (appName: string) =
     let webApp = webApp {
         name appName
         service_plan_name servicePlanName
-        sku WebApp.Sku.B1
+        sku WebApp.Sku.S1
         always_on
         link_to_unmanaged_app_insights (ResourceId.create appInsightsName)
         setting "public_path" "./public"


### PR DESCRIPTION
closes #784 

This is fully automated deployment - we first deploy the "exp" slot, then run the UI tests and then go to production. Slot is created "manually" via Azure CLI because there is no Farmer support for this yet.

Also, to have slots we need to be in the Standard tier, so this also changes. This should be cheaper than having to Basic webs though.